### PR TITLE
Remove redundant comment in Scalar-Analyse script

### DIFF
--- a/simulation/UIDTv3.6.1_Scalar-Analyse.py
+++ b/simulation/UIDTv3.6.1_Scalar-Analyse.py
@@ -35,7 +35,6 @@ class LatticeConfig:
                  N_therm=20, N_meas=50, N_skip=2, seed=12345,
                  kappa=0.5, Lambda=1.0, 
                  m_S=1.705, lambda_S=0.417, v_vev=0.0477):
-        # FIX: Speichere Attribute sowohl als N_... als auch als Nx/Nt
         self.N_spatial = N_spatial
         self.N_temporal = N_temporal
         


### PR DESCRIPTION
This change removes a redundant comment in simulation/UIDTv3.6.1_Scalar-Analyse.py that was originally a placeholder for a fix that has since been implemented. The implementation correctly handles both naming conventions for lattice dimensions, making the comment obsolete.

---
*PR created automatically by Jules for task [7594634166733253882](https://jules.google.com/task/7594634166733253882) started by @badbugsarts-hue*