### PR TITLE
⚡ Optimize Gauge Force memory allocation

### DIFF
--- a/simulation/UIDTv3.6.1_Update-Vector.py
+++ b/simulation/UIDTv3.6.1_Update-Vector.py
@@ -126,9 +126,12 @@ class UIDTLatticeOptimized:
         # Initialize Force Tensor
         F = xp.zeros_like(U, dtype=complex)
         
+        # Pre-allocate staple_sum (Optimization: moved out of loop)
+        staple_sum = xp.zeros_like(U[..., 0, :, :])
+
         # Calculate Staples for each direction mu
         for mu in range(4):
-            staple_sum = xp.zeros_like(U[..., 0, :, :])
+            staple_sum.fill(0)
             
             for nu in range(4):
                 if nu == mu:


### PR DESCRIPTION
The `gauge_force_vectorized` method in `simulation/UIDTv3.6.1_Update-Vector.py` was repeatedly allocating memory for the `staple_sum` array inside a loop. This change moves the allocation outside the loop and uses the in-place `.fill(0)` method to reset the values for each iteration.

Key improvements:
- Reduced memory allocation overhead (from 4 per call to 1 per call).
- Improved performance on both CPU (NumPy) and GPU (CuPy).
- Reduced memory fragmentation.

While numerical benchmarking was impractical due to environment limitations (missing dependencies), this optimization follows standard high-performance computing best practices for lattice simulations.

---
*PR created automatically by Jules for task [13873494673685944486](https://jules.google.com/task/13873494673685944486) started by @badbugsarts-hue*