### PR TITLE
🧪 [UIDT-v3.9] Improve Testing & Fix Edge Case in Cubic Solver

### DIFF
--- a/verification/scripts/UIDT_Master_Verification.py
+++ b/verification/scripts/UIDT_Master_Verification.py
@@ -110,7 +110,9 @@ DELTA_TARGET  = 1.710
 
 def solve_exact_cubic_v(m_S, lambda_S, kappa):
     """Solves the vacuum equation exactly for v."""
-    if lambda_S == 0: return 0.0
+    if lambda_S == 0:
+        # Exact linear physical solution for lambda_S = 0
+        return (kappa * C_GLUON_FLOAT) / (LAMBDA_FLOAT * m_S**2)
     p = (6 * m_S**2) / lambda_S
     q = -(6 * kappa * C_GLUON_FLOAT) / (LAMBDA_FLOAT * lambda_S)
     roots = np.roots([1, 0, p, q])

--- a/verification/tests/test_math_solvers.py
+++ b/verification/tests/test_math_solvers.py
@@ -1,0 +1,88 @@
+import unittest
+import sys
+import os
+import numpy as np
+import mpmath
+from mpmath import mp
+
+# Add script directory to path to import the function
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+SCRIPTS_PATH = os.path.abspath(os.path.join(SCRIPT_DIR, "..", "scripts"))
+PROJECT_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, "..", ".."))
+
+if SCRIPTS_PATH not in sys.path:
+    sys.path.insert(0, SCRIPTS_PATH)
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from UIDT_Master_Verification import solve_exact_cubic_v, C_GLUON_FLOAT, LAMBDA_FLOAT
+
+class TestSolveExactCubicV(unittest.TestCase):
+    def setUp(self):
+        # Set high precision for mpmath checks
+        mp.dps = 80
+
+    def test_happy_path(self):
+        """Test with canonical parameters (m_S=1.705, kappa=0.500, lambda_S=0.417)"""
+        m_S = 1.705
+        kappa = 0.500
+        lambda_S = 0.417
+
+        v = solve_exact_cubic_v(m_S, lambda_S, kappa)
+
+        # Verify it's a root of the equation using mpmath for high-precision residual
+        # m_S^2 * v + lambda_S * v^3 / 6 - kappa * C / Lambda = 0
+        v_mp = mp.mpf(v)
+        m_S_mp = mp.mpf(m_S)
+        lambda_S_mp = mp.mpf(lambda_S)
+        kappa_mp = mp.mpf(kappa)
+        C_mp = mp.mpf(C_GLUON_FLOAT)
+        L_mp = mp.mpf(LAMBDA_FLOAT)
+
+        residual = m_S_mp**2 * v_mp + (lambda_S_mp * v_mp**3)/6 - (kappa_mp * C_mp)/L_mp
+
+        # Since v is from float64 solver (numpy.roots), we expect residual ~ 1e-15 to 1e-16
+        self.assertLess(abs(residual), 1e-14, f"Residual too high: {residual}")
+
+        # Check against canonical VEV (~47.7 MeV)
+        self.assertAlmostEqual(v * 1000, 47.7, delta=0.5)
+
+    def test_lambda_zero(self):
+        """Test edge case lambda_S = 0 (Linear equation)"""
+        m_S = 1.705
+        kappa = 0.500
+        lambda_S = 0.0
+
+        # Mathematical expectation: v = (kappa * C) / (Lambda * m_S**2)
+        expected_v = (kappa * C_GLUON_FLOAT) / (LAMBDA_FLOAT * m_S**2)
+        v = solve_exact_cubic_v(m_S, lambda_S, kappa)
+
+        self.assertAlmostEqual(v, expected_v, places=15,
+                               msg=f"Expected {expected_v}, got {v}. Linear solution failed.")
+
+    def test_kappa_zero(self):
+        """Test edge case kappa = 0 (No gluon coupling)"""
+        # If kappa is 0, v=0 should be a root
+        v = solve_exact_cubic_v(1.705, 0.417, 0.0)
+        self.assertEqual(v, 0.0)
+
+    def test_numerical_stability_small_lambda(self):
+        """Test numerical stability with very small lambda_S"""
+        m_S = 1.705
+        kappa = 0.500
+        lambda_S = 1e-10
+
+        v = solve_exact_cubic_v(m_S, lambda_S, kappa)
+
+        v_mp = mp.mpf(v)
+        m_S_mp = mp.mpf(m_S)
+        lambda_S_mp = mp.mpf(lambda_S)
+        kappa_mp = mp.mpf(kappa)
+        C_mp = mp.mpf(C_GLUON_FLOAT)
+        L_mp = mp.mpf(LAMBDA_FLOAT)
+
+        residual = m_S_mp**2 * v_mp + (lambda_S_mp * v_mp**3)/6 - (kappa_mp * C_mp)/L_mp
+        self.assertLess(abs(residual), 1e-14)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This submission improves the reliability and scientific accuracy of the UIDT v3.9 Master Verification suite.

### 🎯 What:
- Addressed a testing gap by introducing unit tests for the exact cubic solver.
- Corrected a physical discrepancy where the `lambda_S == 0` edge case was incorrectly returning `0.0`.

### 📊 Coverage:
- **Happy Path:** Verified canonical parameters ($m_S=1.705$, $\kappa=0.500$, $\lambda_S=0.417$) against residuals $< 10^{-14}$ using `mpmath`.
- **Edge Cases:** Correctly handles $\kappa=0$ (no coupling) and $\lambda_S=0$ (linear regime).
- **Numerical Stability:** Verified stability for small $\lambda_S$ values.

### ✨ Result:
- Improved mathematical determinism of the framework.
- Ensured the VEV derivation follows the axiomatically correct linear limit when self-coupling vanishes.
- Followed UIDT Constitution regarding high-precision verification and anti-mocking rules.

**Affected Constants & Categories:**
- Coupling $\kappa$: [Category A]
- Self-Coupling $\lambda_S$: [Category A]
- Scalar Mass $m_S$: [Category D] (Prediction)
- VEV $v$: [Category A] (Clean State)

---
*PR created automatically by Jules for task [8457019076835210584](https://jules.google.com/task/8457019076835210584) started by @badbugsarts-hue*