### PR TITLE
Add suptitle and adjust tight_layout in visualization script

### DIFF
--- a/simulation/UIDT-3.6.1-visual.py
+++ b/simulation/UIDT-3.6.1-visual.py
@@ -93,7 +93,8 @@ def plot_parameter_distributions(m_S, kappa, lam):
     ax3.grid(True, alpha=0.3)
     
     # FIX: tight_layout rect parameter handles suptitle overlap issues better
-    plt.tight_layout()
+    fig.suptitle(r"UIDT Framework v3.9 - Physical Parameter Distributions", fontsize=16, fontweight='bold')
+    plt.tight_layout(rect=[0, 0.03, 1, 0.95])
     plt.savefig('uidt_v3.6.1_parameter_dist.png', dpi=300)
     print("🖼️  Saved: uidt_v3.6.1_parameter_dist.png")
 


### PR DESCRIPTION
This PR updates the visualization script `simulation/UIDT-3.6.1-visual.py` to include a proper figure title (`suptitle`) and adjusts the subplot layout to accommodate it.

Changes:
- Added `fig.suptitle(r"UIDT Framework v3.9 - Physical Parameter Distributions", fontsize=16, fontweight='bold')`.
- Replaced `plt.tight_layout()` with `plt.tight_layout(rect=[0, 0.03, 1, 0.95])`.

This ensures the title is visible and does not overlap with the subplots. Verification was done by running the script and confirming the image generation without errors. Generated artifacts were cleaned up before submission.

---
*PR created automatically by Jules for task [14782449678890358753](https://jules.google.com/task/14782449678890358753) started by @badbugsarts-hue*