### PR TITLE
Translate German comments to English in geometric_operator.py

### DIFF
--- a/modules/geometric_operator.py
+++ b/modules/geometric_operator.py
@@ -4,49 +4,49 @@ UIDT MODULE: GEOMETRIC OPERATOR (Pillar I & 0)
 Version: 3.8 (Constructive Synthesis)
 Context: Core Logic / Mathematical Engine
 
-Dieser Modul implementiert den Operator G^, der Massenzustände aus dem Vakuum generiert.
-Er integriert den 'Physical Stress Test' (Unterscheidbarkeits-Prüfung) direkt 
-in die Erzeugungslogik gemäß den ANAM-Prinzipien (Petina).
+This module implements the Operator G^, which generates mass states from the vacuum.
+It integrates the 'Physical Stress Test' (Distinguishability Check) directly
+into the generation logic according to the ANAM principles (Petina).
 """
 
 from mpmath import mp, mpf
 
-# Setze Präzision ausreichend für Banach-Fixpunkt-Verifikation
+# Set precision sufficient for Banach Fixed-Point Verification
 mp.dps = 80
 
 class GeometricOperator:
     def __init__(self):
         """
-        Initialisiert die fundamentalen geometrischen Konstanten der Theorie.
-        Diese Werte sind nicht mehr 'gefittet', sondern als Axiome definiert.
+        Initializes the fundamental geometric constants of the theory.
+        These values are no longer 'fitted', but defined as axioms.
         """
         # 1. PILLAR I: QFT Core Constants
-        # Abgeleitet aus QCD Sum Rules & Banach Fixed Point (v3.7)
+        # Derived from QCD Sum Rules & Banach Fixed Point (v3.7)
         self.DELTA_GAP = mpf('1.710035046742')  # GeV (The "String")
         self.GAMMA = mpf('16.339')              # (The "Scaling")
         
         # 2. PILLAR 0: Logic & Ontology Constants
-        # Wolpert Limit abgeleitet aus X17 Anomalie und thermodynamischer Zensur
+        # Wolpert Limit derived from X17 anomaly and thermodynamic censorship
         self.NOISE_FLOOR = mpf('0.0171')        # 17.1 MeV (Thermodynamic Censorship Limit)
         
-        # 3. Kopplungskonstante (Equipartition Theorem)
+        # 3. Coupling Constant (Equipartition Theorem)
         self.KAPPA = mpf('0.5')
 
     def apply(self, n_harmonic):
         """
-        Wendet den Geometrischen Operator G^ auf den Vakuumzustand |0> an.
-        Eigenwert-Gleichung: G^ |n> = (Delta * gamma^-n)
+        Applies the Geometric Operator G^ to the vacuum state |0>.
+        Eigenvalue Equation: G^ |n> = (Delta * gamma^-n)
         
         Args:
-            n_harmonic (int): Die Oktave (0=Gap, 1=Myon/Vac, 2=Zensiert)
+            n_harmonic (int): The octave (0=Gap, 1=Muon/Vac, 2=Censored)
             
         Returns:
-            mpf: Der rohe geometrische Eigenwert (Energie in GeV)
+            mpf: The raw geometric eigenvalue (Energy in GeV)
         """
         if n_harmonic == 0:
             return self.DELTA_GAP
         
-        # Berechne rohen geometrischen Eigenwert
+        # Calculate raw geometric eigenvalue
         # E_n = Delta / gamma^n
         eigenvalue = self.DELTA_GAP * (self.GAMMA ** (-n_harmonic))
         return eigenvalue
@@ -54,11 +54,11 @@ class GeometricOperator:
     def stress_test(self, energy_gev):
         """
         PILLAR 0 IMPLEMENTATION: Physical Stress Test.
-        Prüft, ob ein generierter Eigenwert vom Vakuumrauschen unterscheidbar ist.
-        Basierend auf Alena Petina's 'Architecture of Necessity'.
+        Checks if a generated eigenvalue is distinguishable from vacuum noise.
+        Based on Alena Petina's 'Architecture of Necessity'.
         
         Returns:
-            (bool, str): Status (True=Stabil, False=Zensiert) und Diagnose.
+            (bool, str): Status (True=Stable, False=Censored) and Diagnosis.
         """
         if energy_gev < self.NOISE_FLOOR:
             return False, f"CENSORED: {energy_gev} GeV < Noise Floor ({self.NOISE_FLOOR} GeV)"


### PR DESCRIPTION
Translate German comments and docstrings in `modules/geometric_operator.py` to English for better maintainability and readability. Preserved all logic and constants. verified with a reproduction script.

---
*PR created automatically by Jules for task [4730178612217512993](https://jules.google.com/task/4730178612217512993) started by @badbugsarts-hue*