### PR TITLE
Refactor: Raw string cleanup in visualization script

### DIFF
--- a/simulation/UIDT-3.6.1-visual.py
+++ b/simulation/UIDT-3.6.1-visual.py
@@ -60,7 +60,6 @@ def plot_parameter_distributions(m_S, kappa, lam):
     xmin, xmax = ax1.get_xlim()
     x = np.linspace(xmin, xmax, 100)
     p = norm.pdf(x, mu, std)
-    # FIX: Raw strings (r'...') for LaTeX
     ax1.plot(x, p, 'r--', linewidth=2, label=rf'Fit: $\mu={mu:.3f}$')
     
     # Targets


### PR DESCRIPTION
- Removed redundant '# FIX: Raw strings (r'...') for LaTeX' comment from simulation/UIDT-3.6.1-visual.py.
- Verified that all LaTeX strings in the file correctly use raw string prefixes (r'' or rf'').

---
*PR created automatically by Jules for task [7704900554340252963](https://jules.google.com/task/7704900554340252963) started by @badbugsarts-hue*