### PR TITLE
Remove redundant attribute storage comment in UIDTv3.6.1_Scalar-Analyse.py

### DIFF
--- a/clay-submission/05_LatticeSimulation/UIDTv3.6.1_Scalar-Analyse.py
+++ b/clay-submission/05_LatticeSimulation/UIDTv3.6.1_Scalar-Analyse.py
@@ -35,7 +35,6 @@ class LatticeConfig:
                  N_therm=20, N_meas=50, N_skip=2, seed=12345,
                  kappa=0.5, Lambda=1.0, 
                  m_S=1.705, lambda_S=0.417, v_vev=0.0477):
-        # FIX: Speichere Attribute sowohl als N_... als auch als Nx/Nt
         self.N_spatial = N_spatial
         self.N_temporal = N_temporal
         


### PR DESCRIPTION
This change removes a redundant TODO comment in `clay-submission/05_LatticeSimulation/UIDTv3.6.1_Scalar-Analyse.py`. The comment `# FIX: Speichere Attribute sowohl als N_... als auch als Nx/Nt` was marking a task that had already been implemented in the lines immediately following it. The removal cleans up the code without altering any logic or functionality.

Testing:
- Verified the script runs without syntax errors.
- Verified output remains consistent.
- Removed generated artifact `scalar_mass_kappa_0.5.png` before submission.

---
*PR created automatically by Jules for task [11188884355924071842](https://jules.google.com/task/11188884355924071842) started by @badbugsarts-hue*