### PR TITLE
📝 [docs] Add heuristic observation for Overlap Shift

### DIFF
--- a/docs/theoretical_notes.md
+++ b/docs/theoretical_notes.md
@@ -1,0 +1,46 @@
+# UIDT Theoretical Notes
+
+> **PURPOSE:** This file documents heuristic observations, potential relationships, and theoretical insights that are currently unproven or have been ruled out as exact derivations.
+> **SCOPE:** Includes evidence categories C, D, and E (Heuristic, Phenomenological, Speculative).
+
+---
+
+## 1. Entropic Overlap Shift vs. D4 Packing Fraction (Heuristic Check)
+
+**Status:** Observed Numerical Proximity (Not Exact)
+**Classification:** **Category D** (Phenomenological/Numerical Approximation)
+**Date:** 2026-02-14
+
+### Observation
+
+The **Entropic Overlap Shift** ($S_{overlap}$) required for the vacuum energy density correction is defined as:
+
+$$ S_{overlap} = \ln(10) \approx 2.302585093 $$
+
+The **4D Sphere Packing Fraction** ($P_{D4}$) for the $D_4$ lattice is:
+
+$$ P_{D4} = \frac{\pi^2}{16} \approx 0.616850275 $$
+
+A search for hidden topological resonances revealed a numerical proximity between the ratio $P_{D4} / S_{overlap}$ and the hexagonal projection constant $2 - \sqrt{3}$:
+
+$$ \frac{P_{D4}}{S_{overlap}} \approx 2 - \sqrt{3} \approx 0.26794919 $$
+
+### Numerical Verification (mp.dps = 80)
+
+Using 80-digit precision, the exact ratio is:
+
+$$ \frac{P_{D4}}{S_{overlap}} = 0.26789467... $$
+
+The target constant is:
+
+$$ 2 - \sqrt{3} = 0.26794919... $$
+
+**Residual:**
+
+$$ \text{Residual} = \left| \frac{P_{D4}}{S_{overlap}} - (2 - \sqrt{3}) \right| \approx 5.45 \times 10^{-5} $$
+
+### Conclusion
+
+A residual of $5.45 \times 10^{-5}$ at `mp.dps=80` proves that **this relationship is NOT exact**. The Entropic Overlap Shift $\ln(10)$ is **irreducible** and cannot be derived directly from the D4 sphere packing density via this specific hexagonal projection.
+
+While the proximity is an interesting coincidence potentially related to effective lattice symmetries, it remains a heuristic observation and is **not a valid derivation** for the overlap shift constant. The overlap shift $\ln(10)$ remains an independent entropic parameter.


### PR DESCRIPTION
This PR adds a new documentation file `docs/theoretical_notes.md` to record the heuristic observation regarding the numerical proximity between the Entropic Overlap Shift ($\ln 10$) and the 4D Sphere Packing Fraction ($\pi^2/16$).

Key points:
- Documents the ratio $P_{D4}/S_{overlap} \approx 2 - \sqrt{3}$.
- Reports the residual of $5.45 \times 10^{-5}$ at `mp.dps=80`.
- Strictly classifies this as **Evidence Category D** (Phenomenological/Numerical Approximation).
- Concludes that $\ln(10)$ is irreducible and the relationship is not exact.

This addresses Task 11 by documenting the findings without modifying any codebase logic.

---
*PR created automatically by Jules for task [13220810131339607960](https://jules.google.com/task/13220810131339607960) started by @badbugsarts-hue*