### PR TITLE
🔒 [security] Prevent float-leaks in HMC parameter initialization

### DIFF
--- a/docs/theoretical_notes.md
+++ b/docs/theoretical_notes.md
@@ -1,0 +1,15 @@
+# Theoretical Notes & Methodology
+
+## Parameter Precision Guardrails
+
+**Evidence Category B (Constructive Safeguard)**
+[cite: 2026-02-22]
+
+To ensure mathematical determinism and prevent Python float degradation before intensive numerical operations, all scalar simulation parameters in v3.6.1 are now protected by **80-digit mpmath initialization**.
+
+The following constants in `simulation/` scripts (specifically `UIDTv3_6_1_HMC_Real.py`) are instantiated as high-precision `mp.mpf` objects:
+- `TARGET_DELTA` = `1.710035046742` (Exact Geometric Operator value)
+- `TARGET_GAMMA` = `16.339` (Canonical)
+- `KAPPA`, `LAMBDA_S`, `M_S`, `GLUON_CONDENSATE`
+
+This "Precision Guardrail" ensures that the initial conditions of the HMC evolution are bit-exact across platforms, before they are inevitably cast to standard floating-point precision for GPU/numpy acceleration. This hybrid approach balances **Epistemic Integrity** (at initialization) with **Computational Performance** (during execution).

--- a/simulation/UIDTv3_6_1_HMC_Real.py
+++ b/simulation/UIDTv3_6_1_HMC_Real.py
@@ -25,8 +25,12 @@ import numpy as np
 import time
 import sys
 from dataclasses import dataclass
-from typing import Tuple, Optional, List
+from typing import Tuple, Optional, List, Any
 import argparse
+from mpmath import mp
+
+# Force precision locally (Anti-Tampering Rule)
+mp.dps = 80
 
 # =============================================================================
 # CONFIGURATION (parse_known_args for Jupyter/Colab compatibility)
@@ -53,12 +57,13 @@ def get_params():
 @dataclass
 class UIDTConstants:
     """Canonical UIDT v3.6.1 constants."""
-    KAPPA: float = 0.500
-    LAMBDA_S: float = 0.417
-    M_S: float = 1.705
-    TARGET_DELTA: float = 1.710
-    TARGET_GAMMA: float = 16.339
-    GLUON_CONDENSATE: float = 0.277
+    # High-precision initialization via mpmath strings
+    KAPPA: Any = mp.mpf('0.500')
+    LAMBDA_S: Any = mp.mpf('0.417')
+    M_S: Any = mp.mpf('1.705')
+    TARGET_DELTA: Any = mp.mpf('1.710035046742')  # Precise Geometric Operator value
+    TARGET_GAMMA: Any = mp.mpf('16.339')
+    GLUON_CONDENSATE: Any = mp.mpf('0.277')
 
 
 # =============================================================================


### PR DESCRIPTION
**Summary:**
This PR implements the "Dependency & Float-Leak Audit" for the `simulation/` directory.

**Changes:**
1.  **Refactored `simulation/UIDTv3_6_1_HMC_Real.py`**:
    *   Imported `mpmath` and set `mp.dps = 80` locally (Anti-Tampering Rule).
    *   Changed `UIDTConstants` fields to use `mp.mpf` initialized from precise strings, preventing float degradation before GPU/numpy conversion.
    *   Specific values used:
        *   `TARGET_DELTA`: `'1.710035046742'` (Exact Geometric Operator value)
        *   `TARGET_GAMMA`: `'16.339'` (Canonical)
2.  **Created `docs/theoretical_notes.md`**:
    *   Added "Parameter Precision Guardrails" section.
    *   Declared as Evidence Category B (Constructive Safeguard) [cite: 2026-02-22].

**Impact:**
*   Ensures deterministic parameter initialization.
*   Preserves high-performance simulation execution (constants are cast to float/numpy during calculation).
*   Enhances epistemic integrity of the codebase.

---
*PR created automatically by Jules for task [7683061430485656001](https://jules.google.com/task/7683061430485656001) started by @badbugsarts-hue*