### PR TITLE
[UIDT-v3.9] fix(manuscript): abstract grammar correction in CSF_UIDT_Unification.tex

### DIFF
--- a/manuscript/CSF_UIDT_Unification.tex
+++ b/manuscript/CSF_UIDT_Unification.tex
@@ -197,7 +197,7 @@ $\rho_{max} = \Delta^4 \gamma^{99}$ required to regularize the Planck
 singularity (\textbf{Theorem~2}). This synthesis yields a parameter-free
 derivation of the dynamical dark energy equation of state
 $w_0 = -0.99$, $w_a = +0.03$ (\textbf{Lemma~2}), providing a manifestly
-DESI Year~5 observations. Furthermore, we rigorously prove the perturbative stability of the vacuum spectral gap $\Delta$ at the infrared fixed point, demonstrating that the phenomenological constant $\gamma$ is topologically protected against running coupling instabilities [Category B].
+    covariant prediction for DESI Year~5 observations. Furthermore, we rigorously prove the perturbative stability of the vacuum spectral gap $\Delta$ at the infrared fixed point, demonstrating that the phenomenological constant $\gamma$ is topologically protected against running coupling instabilities [Category B].
 
 \medskip
 \noindent\textbf{Keywords:}


### PR DESCRIPTION
**Context:**
A grammatical error was identified in the Abstract of `manuscript/CSF_UIDT_Unification.tex` during the daily automated compilation test. The phrase "...providing a manifestly DESI Year~5 observations" was missing a noun/preposition.

**Changes:**
- Corrected the phrase to: "...providing a manifestly covariant prediction for DESI Year~5 observations."
- This aligns with the scientific context of the paper (predicting cosmological parameters).

**Verification:**
- Verified that no other text, equations, or references were modified.
- Constants ($w_0$, $w_a$) and Evidence Classifications remain untouched.
- DOI links preserved.

**Ticket:** TKT-25

---
*PR created automatically by Jules for task [5994968773351375979](https://jules.google.com/task/5994968773351375979) started by @badbugsarts-hue*