### PR TITLE
📝 [theory] Recalibrate LFUV Hypothesis to CMS-2026 Baseline (TKT-20260228-23C)

### DIFF
--- a/docs/theoretical_notes.md
+++ b/docs/theoretical_notes.md
@@ -433,6 +433,33 @@ Using the established electromagnetic shift for the Down quark ($\Delta m_d \app
 
 ---
 
+## 14. Topological Lepton Flavor Universality Violation (LFUV) Hypothesis
+
+**Status:** Under Active Investigation
+**Classification:** **Category D** (Phenomenological Fit / Theoretical Hypothesis)
+**Date:** 2026-02-28
+
+### Theoretical Context
+The UIDT framework posits that the topological scaling of the vacuum lattice inherently predicts a violation of Lepton Flavor Universality (LFUV). In this geometric paradigm, the lepton generations (quantified by the index $n$) couple asymmetrically to the electroweak sector:
+*   The **electron ($n=3$)** couples fully to the electroweak shift.
+*   The **muon ($n=1$)** completely decouples from this correction, maintaining structural alignment with the bare gamma scaling.
+
+### Baseline Calibration (CMS 2026)
+This hypothesis is rigorously calibrated against the most precise current measurements of the weak mixing angle. The calculations rely on the newly reported CMS baseline:
+$$ \sin^2 \theta_{\text{eff}} = 0.23156 \quad \text{(Ref: arXiv:2601.20717)} $$
+
+### The Damping Function
+To model the generation-dependent coupling strength to the electroweak symmetry, a topological damping function $f(n)$ was constructed. This function acts as the exponent in the electroweak correction factor $K(n)$:
+$$ K(n) = (\cos^2\theta_W)^{-f(n)} $$
+
+Using 80-digit precision (`mp.dps=80`), the optimal quadratic damping function required to exactly reproduce the PDG rest masses is found to be:
+$$ f(n) \approx 0.21459 n^2 - 0.35837 n + 0.14377 $$
+
+### Epistemic Caution (HARD-STOP)
+Caution: This quadratic function is strictly a phenomenological fit (Evidence Category D) to correctly map the PDG masses. The ab-initio derivation of these coefficients from the underlying lattice homology and cascade Euler characteristics is still pending.
+
+---
+
 ## Daily Radar Logs (2026)
 
 *   arXiv:2601.20972 (Lambert W EoS) yields $H_0 = 67.4 \pm 1.2$. This $2.5\sigma$ tension to UIDT's $70.4$ confirms that early-universe fits without UIDT vacuum decay ($w_a = -1.30$) cannot reach the local topological equilibrium.


### PR DESCRIPTION
Added documentation for the Topological Lepton Flavor Universality Violation (LFUV) Hypothesis to docs/theoretical_notes.md.

- Discusses lepton generation coupling to the electroweak sector
- Sets baseline using CMS 2026 data
- Incorporates Grok's damping function for mapping PDG rest masses
- Categorized as Evidence Category D with explicitly stated epistemic caution

---
*PR created automatically by Jules for task [9304841054197071614](https://jules.google.com/task/9304841054197071614) started by @badbugsarts-hue*