### PR TITLE
Add verification script for BRST DoF reduction

### DIFF
--- a/verification/scripts/verify_brst_dof_reduction.py
+++ b/verification/scripts/verify_brst_dof_reduction.py
@@ -129,6 +129,7 @@ class StandardModelDoF:
 
         if raw != 118:
              print(f"CRITICAL WARNING: Raw DoF {raw} != 118. Check standard counting.")
+             sys.exit(1)
 
 def main():
     print("=== UIDT Verification: BRST DoF Reduction (v3.9) ===")
@@ -152,6 +153,14 @@ def main():
         sub_val = sum(model.auxiliary[k] for k in match)
         print(f"  Hypothesis {i}: Subtract {match} (Total: {sub_val})")
         print(f"    {model.get_raw_dof()} - {sub_val} = {model.get_raw_dof() - sub_val}")
+
+    # Strict assertion for verification suite (outside the evaluation loop to avoid crashing incorrectly)
+    assert len(matches) > 0, "No subtraction hypotheses yielded target N=99 DoF."
+
+    # Assert each found match exactly reaches the target 99 to fulfill the rigid check without crashing loops
+    for match in matches:
+        sub_val = sum(model.auxiliary[k] for k in match)
+        assert (model.get_raw_dof() - sub_val) == target, f"Match {match} failed to yield exactly {target} DoF"
 
     print("\nVerification Complete.")
 


### PR DESCRIPTION
Added the `verify_brst_dof_reduction.py` script as per the request, mapping 118 raw DoFs to arrays and testing combinations of auxiliary subtractions to find those matching exactly the N=99 target. No mocking is used.

---
*PR created automatically by Jules for task [6100254403473521200](https://jules.google.com/task/6100254403473521200) started by @badbugsarts-hue*