### PR TITLE
fix: stale w₀ values in README + CONSTANTS.md (D-002 compliance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 - Casimir anomaly +0.59% at 0.66 nm (Category D: **predicted, unverified**)
 - Glueball resonance at 1.705 ± 0.015 GeV (Category B: lattice-consistent)
 - Absence of Torsion Energy (E_T → 0) in precision hadron spectroscopy (Category A)
-- DESI dark energy evolution w₀ = -0.762 (Category C: calibrated model)
+- DESI dark energy evolution w₀ = −0.99 [C] (Canonical per Decision D-002, DESI-calibrated)
 - Photonic isomorphism transition at n_critical = γ ≈ 16.339 (Category D+: analog verification)
 
 ---


### PR DESCRIPTION
## Fix: Stale w₀ Values (README + CONSTANTS.md)

### Fixes
1. **README.md L36:** w₀ = -0.762 → w₀ = −0.99 [C] (4th inconsistent value found!)
2. **CANONICAL/CONSTANTS.md:** w₀ = −0.961 → w₀ = −0.99 [C], S1-04 marked RESOLVED

### Decision D-002 Compliance
All w₀ references now point to canonical value −0.99 [C].
Previous values (−0.762, −0.73, −0.961) are superseded.
