### PR TITLE
[UIDT-v3.9] Gamma Derivation Research Claims Registry (TKT-2026-03-09-011)

### DIFF
--- a/docs/research/gamma_derivation_claims.md
+++ b/docs/research/gamma_derivation_claims.md
@@ -1,3 +1,14 @@
-# Placeholder for docs/research/gamma_derivation_claims.md
+# Gamma Derivation Research Claims Registry
 
-This file is part of the Holographic Gamma research plan.
+**Status:** Research [D]
+**Maintained by:** P. Rietz
+
+| ID | Approach | Status | Residual | Evidence | Falsification |
+|----|----------|--------|----------|----------|---------------|
+| D-106 | SU(3) Counting $2(N^2-1)$ | Open | ~0.037% | [B] | Lattice mismatch > 5% |
+| D-107 | RT Holographic | Prototype | 3e-4 | [D] | $\alpha$ tuning failure |
+| D-108 | Proton-Horizon Ratio | Hypoth. | TBD | [D] | No clear power law |
+| D-109 | KS MC-FSS | Closed | <1e-2 | [A-] | Code divergence |
+
+## Reference
+- L4 Limitation: OPEN


### PR DESCRIPTION
## Summary
Registriere alle neuen Forschungsclaims aus der Holografie-Route als [D]-Claims in einem separaten Research-Claims-Dokument. Noch NICHT in CLAIMS.json eintragen (nur ab [B]). Erstelle eine zentrale Uebersicht aller offenen gamma-Derivations-Ansaetze mit Status, Residual und Falsifizierungskriterien.

## Evidence
- Category: [D] (Research/Documentation)
- Ticket: TKT-2026-03-09-011

## Plan
See UIDT-OS/PLANS/TICKETS-TKT/2026-03-09_holographic_gamma/TKT-2026-03-09-011.md