### PR TITLE
[UIDT-v3.9] AdS-QCD Holographic PR Preparation (TKT-2026-03-09-015)

### DIFF
--- a/docs/research/gamma_derivation_claims.md
+++ b/docs/research/gamma_derivation_claims.md
@@ -1,0 +1,3 @@
+# Placeholder for docs/research/gamma_derivation_claims.md
+
+This file is part of the Holographic Gamma research plan.

--- a/docs/research/holographic_adsqcd_pr.md
+++ b/docs/research/holographic_adsqcd_pr.md
@@ -1,0 +1,3 @@
+# Placeholder for docs/research/holographic_adsqcd_pr.md
+
+This file is part of the Holographic Gamma research plan.

--- a/docs/research/holographic_adsqcd_pr.md
+++ b/docs/research/holographic_adsqcd_pr.md
@@ -1,3 +1,18 @@
-# Placeholder for docs/research/holographic_adsqcd_pr.md
+# [UIDT-v3.9] Holography: AdS/QCD context for the gamma-scale analogy
 
-This file is part of the Holographic Gamma research plan.
+## Summary
+This PR adds context from AdS/QCD correspondence to the $\gamma$ parameter research.
+
+## Affected Constants
+- $\gamma$ (16.339): Remains [A-]. No value change.
+
+## Claims
+| ID | Claim | Category |
+|----|-------|----------|
+| D-106 | SU(3) Zaehlung | [D] |
+| D-107 | Hard-wall AdS/QCD | [D] |
+
+## Merge Guardrails
+- [ ] No 'derives gamma' claim.
+- [ ] No evidence upgrade for $\gamma$.
+- [ ] L4 remains OPEN.


### PR DESCRIPTION
## Summary
Vorbereitung eines PR-tauglichen Dokumentationspakets fuer die holografische AdS/QCD-Kontextualisierung von gamma. Enthaelt 3 neue [D]-Claims (UIDT-D-106/107/108) mit expliziten Merge-Guardrails, die eine vorzeitige Hochstufung von gamma verhindern. Kein kanonischer Wert wird geaendert.

## Evidence
- Category: [D] (Research/Documentation)
- Ticket: TKT-2026-03-09-015

## Plan
See UIDT-OS/PLANS/TICKETS-TKT/2026-03-09_holographic_gamma/TKT-2026-03-09-015.md