### PR TITLE
[UIDT-v3.9] Lattice QCD Ratio Falsification Test (TKT-2026-03-09-016)

### DIFF
--- a/docs/research/lattice_qcd_ratio_test.md
+++ b/docs/research/lattice_qcd_ratio_test.md
@@ -1,3 +1,13 @@
-# Placeholder for docs/research/lattice_qcd_ratio_test.md
+# Lattice QCD Ratio Falsification Test
 
-This file is part of the Holographic Gamma research plan.
+## Result
+The ratio $\Delta^* / \Lambda_{\overline{MS}}$ is approximately 7.0.
+This **falsifies** the naive hypothesis that $\gamma \approx 16.339$ is directly this ratio.
+
+## Data
+- $\Delta^* = 1.710$ GeV [A]
+- $\Lambda_{\overline{MS}} \approx 244$ MeV (External Lattice)
+- Ratio: ~7.01
+
+## Conclusion
+Hypothesis $\gamma = \Delta / \Lambda$ is FALSE [D].

--- a/verification/scripts/research/lattice_ratio_test.py
+++ b/verification/scripts/research/lattice_ratio_test.py
@@ -1,3 +1,18 @@
-# Placeholder for verification/scripts/research/lattice_ratio_test.py
+"""
+Lattice Ratio Test (TKT-016)
+"""
+import mpmath as mp
+mp.dps = 80
 
-This file is part of the Holographic Gamma research plan.
+def check_ratio():
+    delta = mp.mpf('1.710')
+    lambda_qcd = mp.mpf('0.244')
+    
+    ratio = delta / lambda_qcd
+    print(f"Ratio: {ratio}")
+    
+    if abs(ratio - 16.339) > 1:
+        print("Hypothesis FALSIFIED.")
+
+if __name__ == "__main__":
+    check_ratio()


### PR DESCRIPTION
## Summary
Dokumentiere das kritische Ergebnis, dass externe SU(3)-Lattice-Bestimmungen fuer Delta/Lambda_QCD typisch ~7 liefern, NICHT ~16. Dies ist ein Falsifizierungssignal fuer die naive Hypothese gamma = Delta/Lambda_QCD und muss als solches im Research-Archiv festgehalten werden.

## Evidence
- Category: [D] (Research/Documentation)
- Ticket: TKT-2026-03-09-016

## Plan
See UIDT-OS/PLANS/TICKETS-TKT/2026-03-09_holographic_gamma/TKT-2026-03-09-016.md