### PR TITLE
[UIDT-v3.9] Gamma-12 Torsion Bridge Derivation (TKT-2026-03-09-017)

### DIFF
--- a/docs/research/gamma12_torsion_bridge.md
+++ b/docs/research/gamma12_torsion_bridge.md
@@ -1,3 +1,17 @@
-# Placeholder for docs/research/gamma12_torsion_bridge.md
+# Gamma-12 Torsion Bridge
 
-This file is part of the Holographic Gamma research plan.
+## Math Error Correction
+The calculation $\Delta^4 / \gamma^{12}$ yields $\approx 2.6 \times 10^{-14}$ GeV$^4$.
+This does **NOT** match the cosmological constant ($10^{-47}$ GeV$^4$).
+Error magnitude: 33 orders of magnitude.
+
+## Torsion Bridge Discovery
+However, the linear mass scale:
+$m_{eff} = \Delta / \gamma^3 \approx 0.392$ MeV.
+$E_{T,calc} = 2\pi m_{eff} \approx 2.463$ MeV.
+
+Canonical $E_T = 2.44$ MeV.
+Residual: < 1%.
+
+## Conclusion
+The $\gamma^{-3}$ scaling relates the Mass Gap to the Torsion Energy.

--- a/verification/scripts/research/gamma12_torsion_bridge.py
+++ b/verification/scripts/research/gamma12_torsion_bridge.py
@@ -1,3 +1,27 @@
-# Placeholder for verification/scripts/research/gamma12_torsion_bridge.py
+"""
+Gamma-12 Torsion Bridge Verification (TKT-017)
+"""
+import mpmath as mp
+mp.dps = 80
 
-This file is part of the Holographic Gamma research plan.
+def verify_bridge():
+    delta = mp.mpf('1.710')
+    gamma = mp.mpf('16.339')
+    et_canonical = mp.mpf('2.44')
+    
+    # Wrong calc check
+    rho_eff = delta**4 / gamma**12
+    print(f"Rho_eff: {rho_eff} (NOT Cosmological Constant)")
+    
+    # Torsion Bridge
+    m_eff = delta / gamma**3
+    et_calc = 2 * mp.pi * m_eff * 1000 # in MeV
+    
+    print(f"E_T Calc: {et_calc} MeV")
+    print(f"E_T Ref:  {et_canonical} MeV")
+    
+    res = abs(et_calc - et_canonical)
+    print(f"Residual: {res}")
+
+if __name__ == "__main__":
+    verify_bridge()


### PR DESCRIPTION
## Summary
Dokumentiere die Entdeckung, dass Delta/gamma^3 * 2*pi ~ 2.463 MeV, was innerhalb <1% des kanonischen Lattice Torsion Binding Energy E_T=2.44 MeV [D] liegt. Dies ist Category E (spekulativ), enthaelt aber einen erkannten Math-Error (gamma^-12 erklaert NICHT die kosmologische Konstante, Fehler 33 Zehnerpotenzen) und einen physikalischen Glueckstreffer (Torsions-Gap statt Dark Energy).

## Evidence
- Category: [D] (Research/Documentation)
- Ticket: TKT-2026-03-09-017

## Plan
See UIDT-OS/PLANS/TICKETS-TKT/2026-03-09_holographic_gamma/TKT-2026-03-09-017.md