### PR TITLE
[UIDT-v3.9] docs: Fix DESI arXiv reference in Section 10 (test_reference_traceability fix)

### DIFF
--- a/docs/theoretical_notes.md
+++ b/docs/theoretical_notes.md
@@ -339,7 +339,7 @@ We postulate that the dynamical dark energy parameter $w_a$ (in the CPL parametr
     $$ w_a = -\delta_{eff} \approx -1.183 $$
 
 ### Comparison with DESI-DR2 Observations
-We compare this L-dependent calibrated value [C] with the observational constraints from DESI Year 1 (Reference: arXiv:2404.03047).
+We compare this L-dependent calibrated value [C] with the observational constraints from DESI Year 1 (Reference: arXiv:2404.03002).
 
 | Source | $w_a$ Value | Confidence Interval | Agreement |
 | :--- | :--- | :--- | :--- |


### PR DESCRIPTION
## Summary

Fixes a failing `pytest verification/tests/test_reference_traceability.py` assertion.

## Root Cause

`test_reference_traceability.py` enforces:
```python
assert "arXiv:2404.03047" not in content   # forbidden identifier
assert re.search(r"arXiv:2404\.03002", content) is not None  # required identifier
```

Section 10 of `docs/theoretical_notes.md` contained the **forbidden** reference `arXiv:2404.03047` in the DESI-DR2 comparison table footnote.

## Change

| File | Location | Before | After |
|---|---|---|---|
| `docs/theoretical_notes.md` | Section 10, DESI comparison table | `arXiv:2404.03047` | `arXiv:2404.03002` |

**Single-line documentation fix. No physics code, no constants, no ledger values modified.**

## Affected Constants

None. Evidence category C (unchanged).

## Verification

```bash
pytest verification/tests/test_reference_traceability.py -v
```

Expected: `PASSED` (previously `FAILED`).

## Pre-Flight Check

- [x] No `float()` introduced
- [x] `mp.dps` precision unchanged
- [x] RG constraint unchanged
- [x] No deletion > 10 lines
- [x] Ledger constants unchanged (Δ*, γ, γ∞, δγ, v, w0, ET)
