### PR TITLE
[UIDT-v3.9] docs: Holographic gamma literature survey - clean recovery (A1)

### DIFF
--- a/docs/research/holographic_gamma_survey.md
+++ b/docs/research/holographic_gamma_survey.md
@@ -1,0 +1,30 @@
+# Holographic Gamma Literature Survey (UIDT-TKT-005)
+
+## 1. Introduction
+This document surveys Stratum-II and III literature for holographic scaling factors relevant to the UIDT parameter $\gamma \approx 16.339$.
+
+## 2. Bekenstein-Horizon Entropy
+Standard formulation: $S_{BH} = \frac{A}{4 l_P^2}$.
+De Sitter Entropy: $S_{dS} = \frac{3 \pi}{G \Lambda}$.
+
+### Analysis
+We check if $N_{Horizon}$ relates to $\gamma$.
+From UIDT-C-050, $N_{eff} \approx 10^{122}$.
+$\ln(N_{eff}) \approx 280$. $\gamma^2 \approx 266$.
+
+## 3. AdS/CFT Scaling Factors
+Ryu-Takayanagi Formula: $S_A = \frac{\text{Area}(\gamma_A)}{4 G_N^{(d+1)}}$.
+Central charges in 4D CFTs often scale as $N^2$.
+For SU(3), $N^2-1 = 8$. 
+$2(N^2-1) = 16$. This is close to 16.339.
+
+## 4. Nonlinear RG Attractors
+Feigenbaum constants: $\delta \approx 4.669$, $\alpha \approx 2.502$.
+Combinations: $\delta \times \alpha \approx 11.6$.
+No direct match found yet in standard universality classes.
+
+## 5. Conclusion
+The most promising Stratum-II analog is the SU(3) degrees of freedom count $2(N^2-1)=16$.
+This supports the "geometric packing" hypothesis of $\gamma$.
+
+**Evidence:** [D]


### PR DESCRIPTION
Reinstating the holographic gamma literature survey. Fixes missing A1 item.

Evidence category: N/A
Limitation impact: none
DOI: 10.5281/zenodo.17835200

# Checklist
- [x] Protected paths unchecked
- [x] No evidence tags elevated