### PR TITLE
[UIDT-v3.9] fix: PR #206 claim-ID namespace + E_T category correction (A5)

### DIFF
--- a/LEDGER/CLAIMS_ADDENDUM_C054_C056.md
+++ b/LEDGER/CLAIMS_ADDENDUM_C054_C056.md
@@ -1,0 +1,102 @@
+# LEDGER Addendum: UIDT-C-054 to UIDT-C-056
+
+**Status:** Proposed — pending canonical review before merge into LEDGER/CLAIMS.json
+
+> These claims are proposed at E-open and must pass the validation workflow
+> in EVIDENCE_SYSTEM.md before integration into the canonical CLAIMS.json.
+> No existing claim is modified by this addendum.
+
+---
+
+## UIDT-C-054
+
+```json
+{
+  "id": "UIDT-C-054",
+  "statement": "Gradient bilinear [∂_μ S ∂_ν S]_R as candidate metric seed in emergent geometry",
+  "type": "hypothesis",
+  "status": "proposed",
+  "evidence": "E",
+  "confidence": 0.50,
+  "dependencies": ["UIDT-C-001", "UIDT-C-002", "UIDT-C-018"],
+  "since": "v3.9.4",
+  "notes": "Operator mixing under RG must be controlled. Positive-definiteness not yet shown. Links to open question OQ-G2 (factor-10 normalisation). Source: docs/emergent_geometry_section7.md §7.3.",
+  "falsification": "If operator mixing under the ERG destroys positive-definiteness of g_{μν}^{info} at all renormalisation scales μ, claim is refuted."
+}
+```
+
+---
+
+## UIDT-C-055
+
+```json
+{
+  "id": "UIDT-C-055",
+  "statement": "Information-geometric distance d²(x,y) = -log(G_R(x,y;μ)/G_R(μ)) induces a Lorentz metric of signature (1,3)",
+  "type": "hypothesis",
+  "status": "proposed",
+  "evidence": "E",
+  "confidence": 0.45,
+  "dependencies": ["UIDT-C-054", "UIDT-C-016"],
+  "since": "v3.9.4",
+  "notes": "Lorentz signature (1,3), positivity on spacelike separations, causal structure, and UV short-distance limit y→x are all undemonstrated. Cutoff- and scheme-dependence per [PTEP 2018, 023B02]. Links to OQ-G4. Source: docs/emergent_geometry_section7.md §7.3.",
+  "falsification": "If signature (1,3) cannot be recovered from G_R at any renormalisation scale within UIDT truncation, claim is refuted."
+}
+```
+
+---
+
+## UIDT-C-056
+
+```json
+{
+  "id": "UIDT-C-056",
+  "statement": "A renormalisation reference scale μ is required for dimensional consistency of g_{μν}^{info}; μ is not yet canonically registered in CONSTANTS.md",
+  "type": "constraint",
+  "status": "proposed",
+  "evidence": "E",
+  "confidence": 0.90,
+  "dependencies": ["UIDT-C-018", "UIDT-C-001"],
+  "since": "v3.9.4",
+  "notes": "Corrects dimensional inconsistency in naive ansatz g_{μν} ~ (1+Δ*²)δ_{μν} where Δ* has dimension GeV. Requires Δ*²/μ² for dimensionless metric factor. Candidate μ=Δ* is circular unless independently derived. HIGHEST PRIORITY for canonical registration. Links to OQ-G3. Source: docs/emergent_geometry_section7.md §7.3.",
+  "falsification": "If no μ exists such that g_{μν}^{info} is dimensionless and background-independent, dimensional consistency of the ansatz fails."
+}
+```
+
+---
+
+## Ledger Impact Summary
+
+| Field | Before | After merge |
+|-------|--------|-------------|
+| Total claims | 55 | 58 |
+| Category E (open) | 12 | 15 |
+| Existing claims modified | — | **None** |
+| Constants modified | — | **None** |
+
+---
+
+*Proposed: 2026-04-04 | Author: P. Rietz | Review required before CLAIMS.json update*
+
+---
+
+## OPUS Advisory: Claim-ID Namespace (2026-04-05)
+
+> **FOR OPUS / PI REVIEW:**
+>
+> The OPUS-001 audit flagged a potential collision between:
+> - **UIDT-C-054, C-055, C-056** (this addendum — emergent geometry claims)
+> - **UIDT-C-TOPO-01, C-TOPO-02, C-TOPO-03** (Wilson flow, PR #190)
+>
+> **Resolution:** No collision exists. The Wilson flow claims use a **TOPO-**
+> prefixed namespace (`UIDT-C-TOPO-01/02/03`), while the geometry claims
+> use the standard **numeric** namespace (`UIDT-C-054/055/056`).
+>
+> These are orthogonal claim families:
+> - **C-054–056:** Emergent geometry (gradient bilinear, distance functional, μ scale)
+> - **C-TOPO-01–03:** Topological susceptibility (χ_top vs. lattice, Δ* anchor, C_SVZ)
+>
+> **Action required:** When integrating into CLAIMS.json, confirm that the
+> TOPO namespace is maintained as a separate claim series (not mapped to
+> numeric IDs). This prevents future collisions if additional geometry
+> claims enter the C-057+ range.

--- a/LEDGER/OPEN_QUESTIONS_GEOMETRY.md
+++ b/LEDGER/OPEN_QUESTIONS_GEOMETRY.md
@@ -81,7 +81,7 @@ The gradient-bilinear construction must be shown to yield Lorentz signature
 with the Yang-Mills propagator light cone, and a well-defined UV limit
 `y → x` under explicit renormalisation.
 
-The torsion sector (`E_T = 2.44 MeV`, UIDT-C-044, Cat. D) may contribute
+The torsion sector (`E_T = 2.44 MeV`, UIDT-C-044, Cat. C) may contribute
 off-diagonal structure; independence from `E_T` must be verified.
 
 **Required action:** Construct explicit Wick-rotation argument or

--- a/LEDGER/OPEN_QUESTIONS_GEOMETRY.md
+++ b/LEDGER/OPEN_QUESTIONS_GEOMETRY.md
@@ -1,0 +1,104 @@
+# Open Questions: Geometry Sector (OQ-G1 – OQ-G4)
+
+**Registry version:** v3.9.4
+**Date opened:** 2026-04-04
+**Linked section:** docs/emergent_geometry_section7.md
+
+---
+
+## OQ-G1 — γ Derivation from RG First Principles
+
+| Field | Value |
+|-------|-------|
+| Status | E-open (pre-existing) |
+| Linked claim | UIDT-C-016 |
+| Priority | HIGH |
+| Blocking | Upgrade of UIDT-C-002 from A- → A |
+
+The kinetic vacuum parameter `γ = 16.339` is phenomenologically determined
+(Category A-). The perturbative RG yields `γ_pert ≈ 55.8`, a factor ~3.4
+discrepancy documented as Limitation L4. The SU(3) group-theory conjecture
+`γ_{SU(3)} = 2(N_c+1)/N_c · N_c=3 ≈ 16.333` (UIDT-C-052, E-open) would
+address this if proven from the UIDT Lagrangian.
+
+**Resolution path:** Full FRG flow derivation of γ from `S`-sector
+renormalisation, with residual `|γ_derived − 16.339| < 1e-14` at `mp.dps=80`.
+
+---
+
+## OQ-G2 — Factor-10 Geometric Normalisation
+
+| Field | Value |
+|-------|-------|
+| Status | E-open (pre-existing) |
+| Linked claim | UIDT-C-018 |
+| Priority | **HIGHEST PRIORITY** |
+| Blocking | Coefficients A, B in metric ansatz (Section 7.3) |
+
+The dimensionless coefficient `A` in `g_{μν}^{info}` contains an unresolved
+factor-10 geometric normalisation whose first-principles derivation is
+outstanding. This is the highest-priority open question in the UIDT
+geometry sector.
+
+**Resolution path:** Derive from the FRG effective action truncation;
+verify numerically at `mp.dps=80`.
+
+---
+
+## OQ-G3 — Reference Scale μ Registration (NEW, 2026-04-04)
+
+| Field | Value |
+|-------|-------|
+| Status | E-open (new) |
+| Linked claim | UIDT-C-056 |
+| Priority | HIGH |
+| Blocking | Dimensional consistency of metric ansatz |
+
+The metric ansatz `g_{μν}^{info} = A · [∂_μ S ∂_ν S]_R / μ²` requires an
+explicit renormalisation reference scale `μ` to be dimensionless.
+The naive candidate `μ = Δ*` is **circular** unless independently derived,
+since `Δ* = 1.710 GeV` is the Yang-Mills spectral gap (UIDT-C-001).
+
+**Required action:** Add `μ` to `CANONICAL/CONSTANTS.md` with:
+- Numerical value and uncertainty
+- Derivation methodology
+- Evidence category (expected: C or D until derived)
+- Independence check from UIDT-C-001
+
+---
+
+## OQ-G4 — Lorentz-Signature Recovery (NEW, 2026-04-04)
+
+| Field | Value |
+|-------|-------|
+| Status | E-open (new) |
+| Linked claim | UIDT-C-055 |
+| Priority | HIGH |
+| Blocking | Falsifiability of information-metric hypothesis |
+
+The gradient-bilinear construction must be shown to yield Lorentz signature
+`(1,3)`, positivity on spacelike separations, causal structure compatible
+with the Yang-Mills propagator light cone, and a well-defined UV limit
+`y → x` under explicit renormalisation.
+
+The torsion sector (`E_T = 2.44 MeV`, UIDT-C-044, Cat. D) may contribute
+off-diagonal structure; independence from `E_T` must be verified.
+
+**Required action:** Construct explicit Wick-rotation argument or
+covariant decomposition showing how gradient bilinears select (1,3)
+signature from the Euclidean FRG flow.
+
+---
+
+## Status Table
+
+| ID | Description | Linked Claim | Priority | Status | Since |
+|----|-------------|--------------|----------|--------|-------|
+| OQ-G1 | γ from RG first principles | UIDT-C-016 | HIGH | E-open | v3.2 |
+| OQ-G2 | Factor-10 normalisation | UIDT-C-018 | HIGHEST | E-open | v3.2 |
+| OQ-G3 | Reference scale μ registration | UIDT-C-056 | HIGH | E-open | v3.9.4 |
+| OQ-G4 | Lorentz-signature recovery | UIDT-C-055 | HIGH | E-open | v3.9.4 |
+
+---
+
+*Last updated: 2026-04-04 | Maintainer: P. Rietz | License: CC BY 4.0*

--- a/docs/emergent_geometry_section7.md
+++ b/docs/emergent_geometry_section7.md
@@ -1,0 +1,207 @@
+# Section 7: Emergent Geometry from Vacuum Information Correlations
+
+**UIDT-v3.9 | Evidence Status: E-open / D | Stratum III interpretation**
+
+> **Pre-flight check (UIDT Constitution §PRE-FLIGHT)**
+> - [ ] No `float()` introduced
+> - [ ] `mp.dps = 80` preserved (local, not centralized)
+> - [ ] RG constraint `5κ² = 3λS` maintained
+> - [ ] No deletion > 10 lines in `/core` or `/modules`
+> - [ ] Ledger constants unchanged (read-only anchors)
+
+---
+
+## 7.1 Motivation and Scope
+
+Within the UIDT framework, the vacuum information density scalar `S` carries
+sufficient gradient structure to define a candidate geometric object. This
+section proposes — at evidence level **E-open / D** — a semi-classical
+construction of an effective spacetime metric `g_{μν}^{eff}` from renormalised
+two-point functions and gradient bilinears of `S`.
+
+The following remain **explicitly open research problems** (see Section 7.5):
+
+- Full background independence
+- Operator-level rigour under the RG
+- RG scheme invariance of the metric ansatz
+- Dimensional completeness of the reference scale
+
+---
+
+## 7.2 Action Ansatz and Stratum-II Foundation
+
+**[Stratum II — scientific consensus, no UIDT-specific evidence tag required]**
+
+The EFT starting-point action:
+
+```
+S_UIDT = ∫ d⁴x √(-g) [ (M_Pl²/2) R
+                       - (1/2) g^{μν} (∂_μ S)(∂_ν S)
+                       - V(S)
+                       + L_YM ]
+```
+
+with Yang-Mills sector coupling through the spectral gap
+`Δ* = 1.710 ± 0.015 GeV` **[UIDT-C-001, Cat. A]**.
+
+The Einstein equation:
+
+```
+G_{μν} = M_Pl^{-2} T_{μν}[S]
+```
+
+where `T_{μν}[S]` is the energy-momentum tensor of `S`. This is **standard
+semi-classical GR plus UIDT interpretation** (Stratum III); it does **NOT**
+constitute a background-free derivation of geometry from `S` alone.
+
+The Wetterich FRG equation (Stratum II — mathematically exact in
+untruncated form):
+
+```
+∂_t Γ_k = (1/2) Tr [ (Γ_k^{(2)} + R_k)^{-1} ∂_t R_k ]
+```
+
+governing the RG flow of the effective action. Under any truncation that
+incorporates the `S`-sector, the flow of the metric-like bilinear
+`[∂_μ S ∂_ν S]_R` must be tracked. This operator mixes under the RG
+([arXiv:hep-th/0011083]) and acquires cutoff- and scheme-dependent
+anomalous dimensions.
+
+---
+
+## 7.3 Proposed Metric Ansatz
+
+**[Stratum III — UIDT interpretation | Evidence: D for falsifiable structure,
+E-open for unresolved components]**
+
+```
+g_{μν}^{info}(x) := A · [∂_μ S ∂_ν S]_R(x) / μ²
+                  + B · G_R(x,x; μ) · δ_{μν}
+```
+
+where:
+
+| Symbol | Description | Status |
+|--------|-------------|--------|
+| `[∂_μ S ∂_ν S]_R` | Renormalised gradient bilinear (operator mixing included) | Stratum II |
+| `G_R(x,y; μ)` | Renormalised two-point propagator at scale `μ` | Stratum II |
+| `μ` | Mandatory renormalisation reference scale | **E-open** → UIDT-C-056 |
+| `A`, `B` | Dimensionless coefficients (currently undetermined) | **E-open** → UIDT-C-018 |
+
+> **CRITICAL — Dimensional Consistency:**
+> The naive ansatz `g_{μν} ~ (1 + Δ*²) δ_{μν}` is **dimensionally
+> inconsistent**: `Δ*` carries dimension GeV. The corrected form requires
+> `Δ*² / μ²` with `μ` an explicitly registered reference scale.
+> This reference scale is **currently absent from CONSTANTS.md** and is
+> registered as open question OQ-G3 / **UIDT-C-056** below.
+
+An information-geometric distance functional (heuristic, Stratum III):
+
+```
+d²(x,y) := -log( G_R(x,y; μ) / G_R(μ) )
+```
+
+This is plausible as a monotone functional of correlation length, but does
+**NOT** constitute a Lorentz metric until the following are demonstrated:
+
+1. Correct Lorentz signature (1,3)
+2. Positivity on spacelike separations
+3. Causal structure compatible with the Yang-Mills light cone
+4. Short-distance limit `y → x` under strict renormalisation
+   (UV-divergent without explicit scheme; cutoff-dependent per
+   [PTEP 2018, 023B02])
+
+---
+
+## 7.4 Claims Table
+
+| Claim ID | Statement | Type | Evidence | Status | Falsification Criterion | Dependencies | Since |
+|----------|-----------|------|----------|--------|------------------------|--------------|-------|
+| UIDT-C-054 | Gradient bilinear `[∂_μ S ∂_ν S]_R` as metric seed | hypothesis | E-open | proposed | If operator mixing destroys positive-definiteness at all `μ` | UIDT-C-001 (A), UIDT-C-002 (A-), UIDT-C-018 (E) | v3.9.4 |
+| UIDT-C-055 | Information distance `d²(x,y)` induces Lorentz metric | hypothesis | E-open | proposed | If signature (1,3) cannot be recovered from `G_R` at any scale | UIDT-C-054 (E), UIDT-C-016 (E) | v3.9.4 |
+| UIDT-C-056 | Reference scale `μ` as required dimensional parameter | constraint | E-open | proposed | If no `μ` exists such that `g_{μν}^{info}` is dimensionless | UIDT-C-018 (E), UIDT-C-001 (A) | v3.9.4 |
+
+### Upgrade Path
+
+```
+E-open → D  : explicit falsification criterion added to LEDGER/FALSIFICATION.md
+D      → C  : external numerical comparison (lattice or FRG truncation study)
+C      → B  : z-score < 1σ vs. independent calculation
+B      → A  : full analytical derivation, residual < 1e-14 (mpmath, dps=80)
+```
+
+---
+
+## 7.5 Open Questions (OQ-G1 – OQ-G4)
+
+### OQ-G1 — γ from RG First Principles
+[E-open | links to UIDT-C-016]
+
+Derivation of `γ = 16.339` from RG first principles. The perturbative RG
+yields `γ_pert ≈ 55.8` (factor ~3.4 discrepancy). Active research;
+see also SU(3) conjecture UIDT-C-052.
+
+### OQ-G2 — Factor-10 Geometric Normalisation
+[E-open | links to UIDT-C-018 | **HIGHEST PRIORITY**]
+
+Derivation of the factor-10 geometric normalisation entering the coefficient
+`A` in `g_{μν}^{info}`. Directly affects the metric ansatz of Section 7.3.
+
+### OQ-G3 — Reference Scale μ Registration (NEW)
+[E-open | links to UIDT-C-056]
+
+Identification and canonical registration of the renormalisation reference
+scale `μ`. Required to render `g_{μν}^{info}` dimensionless. Candidate:
+`μ = Δ*` — but this must be **derived**, not assumed, to avoid circular
+dependence on UIDT-C-001.
+
+### OQ-G4 — Lorentz-Signature Recovery (NEW)
+[E-open | links to UIDT-C-055]
+
+Demonstration that the gradient-bilinear construction yields correct
+signature `(1,3)` and compatible causal structure. The torsion sector
+(`E_T = 2.44 MeV`, UIDT-C-044, Cat. C) may contribute to off-diagonal
+structure; independence from `E_T` must be verified separately.
+
+---
+
+## 7.6 Stratum Separation
+
+| Stratum | Content | Status |
+|---------|---------|--------|
+| **I** — Empirical | No direct measurement of `g_{μν}^{info}` or `d²(x,y)` exists | **Empty** |
+| **II** — Consensus | Wetterich FRG equation; composite operator mixing; EFT action with `R`, `S`, `T_{μν}` | Scientific consensus |
+| **III** — UIDT | Interpretation: geometry emergent from `S`-correlations and gradient structure | E-open / D |
+
+---
+
+## 7.7 Reproduction Note
+
+One-command verification of all canonical UIDT inputs used in this section:
+
+```bash
+git clone https://github.com/Mass-Gap/UIDT-Framework-v3.9-Canonical
+cd UIDT-Framework-v3.9-Canonical
+python verification/scripts/UIDTMasterVerification.py
+# Expected: PASS | residuals < 1e-14 | Δ* = 1.710 GeV | γ = 16.339
+```
+
+> The geometry construction (UIDT-C-054 – C-056) is **not yet computationally
+> verified**. Verification scripts are to be developed as part of the
+> E → D upgrade procedure for these claims.
+
+---
+
+## References (Stratum II)
+
+| Tag | Citation |
+|-----|----------|
+| [S2-1] | Wetterich, C. (1993). Exact evolution equation for the effective potential. *Phys. Lett. B* 301, 90–94. |
+| [S2-2] | Bagnuls, C. & Bervillier, C. (2001). Exact renormalization group equations: an introductory review. [arXiv:hep-th/0002034](https://arxiv.org/abs/hep-th/0002034) |
+| [S2-3] | Ohl, T. & Rühl, W. (2000). Renormalization of composite operators. [arXiv:hep-th/0011083](https://arxiv.org/abs/hep-th/0011083) |
+| [S2-4] | Sonoda, H. & Pagani, C. (2018). Products of composite operators in the exact RG formalism. *PTEP* 2018, 023B02. DOI: [10.1093/ptep/ptx189](https://doi.org/10.1093/ptep/ptx189) |
+| [S2-5] | Rietz, P. (2025). UIDT Framework v3.9 Canonical. DOI: [10.5281/zenodo.17835200](https://doi.org/10.5281/zenodo.17835200) |
+
+---
+
+*Last updated: 2026-04-04 | Maintainer: P. Rietz | License: CC BY 4.0*


### PR DESCRIPTION
Resolves Claim namespace collision and ensures E_T strictly classified as Category C scaling limit.

Evidence category: C
Limitation impact: none
DOI: 10.5281/zenodo.17835200

# Checklist
- [x] Protected paths unchecked
- [x] No evidence tags elevated