### PR TITLE
[UIDT-v3.9] docs: Recover 2 audit docs from deleted branch (#275)

### DIFF
--- a/docs/qa/TKT-20260403-audit-summary.md
+++ b/docs/qa/TKT-20260403-audit-summary.md
@@ -1,0 +1,67 @@
+# Audit Summary — TKT-20260403
+
+**Date:** 2026-04-03  
+**Scope:** Three open analytical questions from session analysis  
+**Status:** RESOLVED with explicit epistemic outcome per question
+
+---
+
+## Q1 — Formal derivation γ = Δ*/v → 49/3 from Banach + Gap equation
+
+**Result:** NOT PROVABLE from current equations.
+
+- Closed form from Gap equation + VEV stability: $\gamma^3 = 6\Delta^{*3}\lambda_S/(13\kappa\mathcal{C}) \Rightarrow \gamma \approx 1.91$
+- To obtain 49/3 from Gap eq. requires $\Delta^* \approx 14.6$ GeV — inconsistent with Banach fixed point
+- **Conclusion:** $\gamma \approx 49/3$ is a numerical coincidence (0.037%), not a theorem
+- **Evidence category remains [A-] Conjecture**
+- See `docs/su3_gamma_theorem.md` for updated explicit limitation
+
+**Open ticket:** L4 (functional determinant derivation) — remains open
+
+---
+
+## Q2 — FRG-NLO correction δ_NLO from Wetterich equation at k=Δ*
+
+**Result:** FRG-NLO route is REFUTED as origin of δγ.
+
+- Wetterich eq., Litim regulator, $k=\Delta^*$, $g^{*2}=1.0$:
+  $$\delta_{\text{NLO}} = \frac{49}{3}\cdot\frac{\eta_A^{\text{NLO}}}{2} \approx 0.0437$$
+- Ledger: $\delta\gamma = 0.0047$ → factor ~9 discrepancy
+- **Conclusion:** $\delta\gamma = 0.0047$ is a **finite-size scaling (FSS) artefact** from  
+  thermodynamic-limit extrapolation $\gamma_\infty = 16.3437$, not a FRG correction
+- **Evidence category: [B]** (confirmed, origin now explicit)
+
+---
+
+## Q3 — RG Fixed-Point Constraint 5κ² = 3λ_S, residual 0.001
+
+**Result:** FIXED — λ_S corrected to exact value 5/12.
+
+| Before | After |
+|--------|-------|
+| $\lambda_S = 0.417$ (rounded) | $\lambda_S = 5\kappa^2/3 = 5/12$ (exact) |
+| Residual: 0.001 | Residual: < 1e-78 (mp.dps=80) |
+| Evidence [A] (tol. 0.01) | Evidence **[A] (tol. < 1e-14)** |
+
+- Correction within existing uncertainty $\pm 0.007$ — no physics change
+- See `docs/rg_lambda_exact_fix.md` for full analysis
+- All verification scripts must be updated to use `mp.mpf('5')/mp.mpf('12')` for λ_S
+
+---
+
+## Claims Table
+
+| ID | Claim | Category | Source | Change |
+|----|-------|----------|--------|--------|
+| C-RG-001 | 5κ²=3λ_S residual <1e-14 | A | algebraic, mp.dps=80 | UPGRADED |
+| C-GAM-001 | γ=49/3 formal proof from Gap eq. | A- | conjecture only | DOWNGRADED to explicit limit |
+| C-FRG-001 | δγ = δ_NLO^FRG | E | refuted numerically | NEW — REFUTED |
+| C-FSS-001 | δγ=0.0047 is FSS artefact | B | FSS extrapolation | CONFIRMED |
+
+## Reproduction Note
+
+```bash
+# One-command verification (after scripts updated with λ_S=5/12):
+python3 verification/scripts/rg_constraint_exact.py
+# Expected output: RG_CONSTRAINT_PASS residual < 1e-14
+```

--- a/docs/rg_lambda_exact_fix.md
+++ b/docs/rg_lambda_exact_fix.md
@@ -1,0 +1,68 @@
+# RG Fixed-Point Constraint: λ_S Exact Correction
+
+**Ticket:** TKT-20260403-rg-lambda-exact  
+**Date:** 2026-04-03  
+**Evidence Category:** [A] (analytically proven, residual < 1e-14)
+
+## Problem Statement
+
+The RG fixed-point constraint
+
+$$5\kappa^2 = 3\lambda_S$$
+
+requires at $\kappa = 0.500$ exactly:
+
+$$\lambda_S^{\text{exact}} = \frac{5\kappa^2}{3} = \frac{5 \cdot 0.25}{3} = \frac{5}{12} = 0.41\overline{6}$$
+
+The ledger carried $\lambda_S = 0.417$, which is a rounding of this exact value.
+
+## Residual Analysis (mp.dps=80)
+
+| Configuration | LHS = 5κ² | RHS = 3λ_S | Residual |
+|---|---|---|---|
+| Ledger (λ_S = 0.417) | 1.250000 | 1.251000 | **0.001000** (>1e-14 ❌) |
+| Corrected (λ_S = 5/12) | 1.250000 | 1.250000 | **< 1e-78** ✅ |
+
+The corrected value lies within the existing ledger uncertainty $\pm 0.007$, so no physical  
+content changes. This is a precision bookkeeping fix only.
+
+## Correction Applied
+
+```
+- λ_S = 0.417   (rounded, residual 0.001)
++ λ_S = 5/12    (exact RG fixed point, residual < 1e-78 at mp.dps=80)
+```
+
+In code, this must be represented as:
+
+```python
+import mpmath as mp
+mp.dps = 80
+kappa = mp.mpf('1') / mp.mpf('2')
+lambda_S = 5 * kappa**2 / 3  # exact: 5/12
+```
+
+**Never use** `mp.mpf('0.417')` in verification scripts after this fix.
+
+## Derived Quantities — Impact Assessment
+
+| Quantity | Before fix | After fix | Δ | Physical impact |
+|---|---|---|---|---|
+| $m_S = \sqrt{2\lambda_S}\,v$ | 1.7043 GeV | 1.7032 GeV | −1.1 MeV | within $\Delta^*$ uncertainty |
+| RG residual | 0.001 | <1e-78 | — | constraint now exact [A] |
+| $\gamma$ ledger | unchanged | unchanged | 0 | no change |
+| Evidence category | A (tol. 0.01) | **A (tol. 1e-14)** | upgrade | |
+
+## Verification
+
+```bash
+cd verification/scripts
+python3 rg_constraint_exact.py
+# Expected: RG_CONSTRAINT_PASS, residual < 1e-14
+```
+
+## Affected Ledger Files
+
+- `FORMALISM.md` — RG section: update numerical value
+- `CONSTANTS.md` — Quick-Copy block: λ_S = 5/12 ≈ 0.41667
+- All verification scripts using `mp.mpf('0.417')`


### PR DESCRIPTION
Recovery of 2 documentation files from deleted branch (PR #275).

Recovered via commit SHA cc0c4873f780:
- docs/qa/TKT-20260403-audit-summary.md (audit summary for γ, λ_S, FRG)
- docs/rg_lambda_exact_fix.md (λ_S exact correction documentation)

No scientific data was lost — these are supplementary documentation about fixes already on main.

Evidence: N/A | DOI: 10.5281/zenodo.17835200