### PR TITLE
[UIDT-v3.9] Research: Banach-γ Derivation Roadmap — Free Parameter vs. Formal Derivation

### DIFF
--- a/docs/research/banach_gamma_derivation_roadmap_20260415.md
+++ b/docs/research/banach_gamma_derivation_roadmap_20260415.md
@@ -1,0 +1,190 @@
+# UIDT Research Document: Banach-γ Derivation Roadmap
+
+**Author:** P. Rietz (Maintainer)  
+**Date:** 2026-04-15  
+**Version:** 0.1 (Working Draft)  
+**Status:** OPEN RESEARCH — Evidence [E] → target [A]
+
+---
+
+## The Central Question
+
+Is `γ = 16.339` a **free parameter** of the UIDT formalism,
+or does it **follow uniquely** from the Yang–Mills field equations and the
+UIDT Lagrangian?
+
+This document maps the mathematical preconditions and research strategy
+required to answer this question.
+
+---
+
+## Current Ledger Status of γ
+
+| Claim | Value | Evidence | Status |
+|---|---|---|---|
+| UIDT-C-002 | `γ = 16.339` (kinetic VEV) | A- | Calibrated, phenomenological |
+| UIDT-C-003 | `γ_MC = 16.374 ± 1.005` | A- | Monte Carlo statistical |
+| UIDT-C-043 | `γ_∞ = 16.3437 ± 0.0005` | B | Finite-size scaling L→∞ |
+| UIDT-C-052 | `γ_SU(3) = 49/3 ≈ 16.333` | E | Conjecture only, unproven |
+| UIDT-C-016 | γ derivation from RG | E | Open research |
+| UIDT-C-040 | γ from RG first principles | E | Open research |
+
+**The gap:** No existing UIDT claim has Evidence ≥ [A-] for a *derivation* of `γ`.
+All [A-] entries refer to the *measured/calibrated value*, not its theoretical origin.
+
+---
+
+## What a Proof Would Require
+
+A Banach-type uniqueness proof for `γ` (analogous to the existing proof for `Δ*`)
+requires three layers:
+
+### Layer 1 — Formal Definition (missing)
+
+`γ` must be defined as the expectation value of a specific operator in the
+UIDT vacuum. The definition must be:
+
+- Written in UIDT/SU(3) notation
+- Derivable from the UIDT Lagrangian
+- Independent of numerical calibration
+
+**Candidate:** If `γ` is the kinetic VEV, the operator is likely of the form
+`γ = ⟨Φ | T_kin | Φ⟩ / ⟨Φ | Φ⟩` for the vacuum state `|Φ⟩`.
+This form has not been formally established in the current UIDT documents.
+
+### Layer 2 — Existence of a Fixed-Point Equation (missing)
+
+A Banach proof requires a contraction operator `T` such that `T(γ) = γ`.
+This equation must emerge from the UIDT field equations, not be postulated.
+
+**Candidate path (SU(3) Casimir route):**
+The conjecture UIDT-C-052 gives `γ_SU(3) = (2N_c+1)^2/N_c = 49/3`.
+A proof would show that integrating out the non-abelian gauge modes in SU(3)
+leads to a kinetic term normalization factor of exactly `49/3`.
+This requires:
+- Computing `Tr(T^a T^b)` sums over SU(3) generators in the kinetic sector
+- Showing that the normalization is unique (Casimir constraint)
+- Establishing that this factor equals the measured VEV
+
+**Candidate path (RG fixed-point route):**
+The perturbative RG gives `γ* ≈ 55.8` (not 16.339).
+A non-perturbative fixed point at `γ = 16.339` would require:
+- Identifying a beta function `β(γ)` that vanishes exactly at `γ = 16.339`
+- Showing this zero is unique and attractive
+- Numerical verification with `mpmath` at 80 dps: `|β(γ)| < 10^{-14}`
+
+### Layer 3 — Uniqueness and Continuity (missing)
+
+Banach Fixed Point Theorem conditions:
+
+1. Complete metric space `(X, d)` containing the possible values of `γ`
+2. Contraction constant `q < 1` such that `d(T(γ₁), T(γ₂)) ≤ q · d(γ₁, γ₂)`
+3. Unique fixed point `γ* = lim_{n→∞} T^n(γ_0)` for any starting value `γ_0`
+4. Error bound: `d(γ_n, γ*) ≤ (q^n / (1-q)) · d(γ_1, γ_0)`
+
+None of these conditions have been verified for `γ` in the UIDT formalism.
+
+---
+
+## Numerical Verification Targets (once Layer 1+2 are established)
+
+All computations must use `mpmath` with `mp.dps = 80`. No `float()`, no `round()`.
+
+```python
+import mpmath as mp
+mp.dps = 80
+
+# Ledger constants (IMMUTABLE)
+gamma   = mp.mpf('16.339')
+gamma_inf = mp.mpf('16.3437')
+gamma_su3 = mp.mpf('49') / mp.mpf('3')  # 16.333...
+delta   = mp.mpf('1.710')  # GeV
+kappa   = mp.mpf('0.500')
+lambda_S = mp.mpf('5') * kappa**2 / mp.mpf('3')  # exact, PI Decision D6
+
+# RG constraint check (MANDATORY before any gamma computation)
+rg_residual = abs(mp.mpf('5') * kappa**2 - mp.mpf('3') * lambda_S)
+assert rg_residual < mp.mpf('1e-14'), f'[RG_CONSTRAINT_FAIL] residual={rg_residual}'
+
+# SU(3) conjecture check
+su3_deviation = abs(gamma - gamma_su3) / gamma
+# Expected: su3_deviation ≈ 3.68e-4 (0.037%)
+```
+
+---
+
+## Research Strategy (LLM-Assisted, PI-Led)
+
+### Phase 1: Operator Definition (PI task, not LLM)
+
+P. Rietz writes the formal definition of `γ` as a UIDT operator expectation value.
+No LLM input at this stage — the Constitution prohibits guessing on field equations.
+
+### Phase 2: Candidate Equation Search (LLM-assisted)
+
+Once the operator is defined, LLM assistance is permitted for:
+- Systematic enumeration of SU(3) algebraic structures that could produce `49/3`
+- Symbolic trace calculations over generator products `Tr(T^a T^b T^c ...)`
+- Lipschitz constant estimation for candidate contraction operators
+- Literature search (arXiv, Inspire-HEP) for related fixed-point results
+
+**Hard rule:** Every LLM-suggested candidate must pass `mpmath` numerical
+verification before being recorded as a Claim candidate.
+
+### Phase 3: Negative Selection (automated)
+
+A Python script (`verification/scripts/gamma_candidate_filter.py`) tests:
+1. Does candidate `f(γ_{candidate})` match `16.339` within `|Δγ| < 0.001`?
+2. Does it respect `γ_∞ = 16.3437 ± 0.0005` (UIDT-C-043)?
+3. Does it remain consistent with the RG constraint `5κ² = 3λ_S`?
+4. Does it survive torsion kill-switch: if `E_T = 0`, does `Σ_T = 0` follow?
+
+Only candidates passing all four tests proceed to Phase 4.
+
+### Phase 4: Banach Proof Attempt (PI + LLM symbolic assistance)
+
+- Formulate `T(γ) = γ` from the surviving candidate
+- Estimate contraction constant `q`
+- Verify `q < 1` numerically at 80 dps
+- Formulate proof sketch for external review
+- If successful: upgrade UIDT-C-016 and UIDT-C-052 from [E] to [A]
+
+---
+
+## Known Obstacles
+
+| Obstacle | Impact | Priority |
+|---|---|---|
+| `γ` has no formal operator definition in current UIDT docs | Blocks all proof attempts | CRITICAL |
+| Perturbative RG gives `γ* ≈ 55.8`, not `16.339` | Suggests non-perturbative origin | HIGH |
+| SU(3) conjecture `49/3` has 0.037% deviation from `16.339` | May indicate rounding or residual | MEDIUM |
+| N=99 self-contradiction (C-017 vs C-046) | Contaminates any N-dependent formula | HIGH |
+
+---
+
+## Decision Required from PI
+
+> **Which derivation path should be pursued first?**
+>
+> Option A: SU(3) Casimir route (γ = 49/3 from generator algebra)  
+> Option B: RG fixed-point route (β(γ*) = 0 for non-perturbative β-function)  
+> Option C: Resolve N=99 contradiction first (prerequisite for some paths)
+
+PI decision required before Phase 2 begins.
+
+---
+
+## Affected Ledger Claims
+
+| Claim ID | Current Evidence | Target if Proven |
+|---|---|---|
+| UIDT-C-002 | A- (calibrated) | A (derived) |
+| UIDT-C-016 | E (open) | A (closed) |
+| UIDT-C-040 | E (open) | A (closed) |
+| UIDT-C-052 | E (conjecture) | A (theorem) |
+
+---
+
+*UIDT Constitution v4.1 applies. No Ledger values may be modified without PI decision.*  
+*All numerical verification must use mpmath mp.dps = 80.*  
+*Language: English (repository output).*


### PR DESCRIPTION
## Summary

This PR documents the formal research roadmap for the central open question:

> Is `γ = 16.339` a **free parameter**, or does it **follow uniquely** from the
> UIDT formalism (Yang–Mills + UIDT Lagrangian)?

This is the mathematically decisive question for UIDT's status: a free parameter
remains phenomenological [A-]; a proven derivation would elevate to [A].

## What This PR Contains

A working-draft research document mapping:

1. Current Ledger status of all γ-related claims (C-002, C-016, C-040, C-043, C-052)
2. Three mathematical layers required for a Banach-type uniqueness proof
3. Two candidate derivation paths (SU(3) Casimir route, RG fixed-point route)
4. Automated numerical filter specification (mpmath 80 dps)
5. PI decision request: which path to pursue first

## Affected Ledger Claims

| Claim | Current Evidence | Target if Proven |
|---|---|---|
| UIDT-C-002 | A- (calibrated) | A (derived) |
| UIDT-C-016 | E (open) | A (closed) |
| UIDT-C-040 | E (open) | A (closed) |
| UIDT-C-052 | E (conjecture) | A (theorem) |

**No Ledger values are modified in this PR.** This is a planning document only.

## Key Obstacle Identified

`γ` currently has no formal operator definition in the UIDT documents. All proof
attempts are blocked until the PI provides this definition. The document makes this
explicit and requests a PI decision on derivation path.

## PI Action Required

> Choose derivation path: (A) SU(3) Casimir, (B) RG β-function fixed point, or
> (C) Resolve N=99 contradiction first.

## Files Changed

- `docs/research/banach_gamma_derivation_roadmap_20260415.md` — Full roadmap

---
*UIDT Constitution v4.1 — Priority: truth > reproducibility > mathematical rigor > narrative coherence*
*All future verification uses mpmath mp.dps = 80, no float(), no round().*