### PR TITLE
🛠️ [infra] S0-Remediation: Migrate UIDT-test.py to 80-dps mpmath [UNTESTED-AIRGAPPED] (TKT-20260305-TrueHealth)

### DIFF
--- a/simulation/UIDTv3.6.1_UIDT-test.py
+++ b/simulation/UIDTv3.6.1_UIDT-test.py
@@ -11,21 +11,23 @@ Synchronized with Manuscript v3.6.1:
 - Mass Gap: 1.710 GeV
 """
 
-import numpy as np
-from scipy.optimize import fsolve
-from scipy.constants import physical_constants
+import mpmath
+
+# 80-dps Precision Enforcement (UIDT v3.9 S0-Rule)
+mpmath.mp.dps = 80
 
 # =============================================================================
 # I. CONSTANTS & TARGETS (v3.6.1 CLEAN STATE)
 # =============================================================================
 class UIDT_CONSTANTS:
-    C_QCD = 0.277         # Gluon Condensate [GeV^4]
-    LAMBDA = 1.0          # Effective Scale [GeV]
-    TARGET_DELTA = 1.710  # Mass Gap [GeV]
-    TARGET_GAMMA = 16.339 # Canonical Gamma Invariant
+    # Cast all constants to 80-dps mpf for precision closure
+    C_QCD = mpmath.mpf('0.277')         # Gluon Condensate [GeV^4]
+    LAMBDA = mpmath.mpf('1.0')           # Effective Scale [GeV]
+    TARGET_DELTA = mpmath.mpf('1.710')   # Mass Gap [GeV]
+    TARGET_GAMMA = mpmath.mpf('16.339')  # Canonical Gamma Invariant
     
     # NEW CLEAN STATE PARAMETER
-    VEV_CANONICAL = 0.0477 # 47.7 MeV
+    VEV_CANONICAL = mpmath.mpf('0.0477') # 47.7 MeV
 
 class LATTICE_SETUP:
     L_SPATIAL = 16
@@ -44,8 +46,7 @@ def solve_canonical_parameters():
     print("\n🔍 UIDT PARAMETER SOLVER (v3.6.1 Logic)")
     print("="*40)
     
-    def equations(vars):
-        m_S, kappa, lambda_S = vars
+    def equations(m_S, kappa, lambda_S):
         v = UIDT_CONSTANTS.VEV_CANONICAL
         Lam = UIDT_CONSTANTS.LAMBDA
         C = UIDT_CONSTANTS.C_QCD
@@ -71,9 +72,12 @@ def solve_canonical_parameters():
     guess = [1.70, 0.5, 0.4]
     
     try:
-        m_S, kappa, lambda_S = fsolve(equations, guess)
+        # mpmath.findroot for systems with x0 as list calls func(*x0)
+        # Result is an mpmath matrix [3x1]
+        solution = mpmath.findroot(equations, guess)
+        m_S, kappa, lambda_S = solution[0], solution[1], solution[2]
         
-        print(f"✅ SOLUTION FOUND:")
+        print(f"✅ SOLUTION FOUND (80-dps):")
         print(f"   m_S      = {m_S:.6f} GeV")
         print(f"   kappa    = {kappa:.6f}")
         print(f"   lambda_S = {lambda_S:.6f}")
@@ -98,9 +102,9 @@ if __name__ == "__main__":
         # 2. Check Gamma Consistency
         # Gamma = Mass Gap / VEV approx (or derived scaling)
         # Here we check if the derived parameters yield the invariant
-        gamma_check = m_S / (v * np.sqrt(lam)) # Heuristic check
+        gamma_check = m_S / (v * mpmath.sqrt(lam)) # Heuristic check
         
-        print("\n📋 SIMULATION SETUP:")
+        print("\n📋 SIMULATION SETUP (UIDT Canonical):")
         print(f"   Target Gamma: {UIDT_CONSTANTS.TARGET_GAMMA}")
         print(f"   Status:       READY FOR HMC")
         print(f"   Action:       Use 'UIDTv3.2_Ape-smearing.py' for production.")

--- a/simulation/UIDTv3.6.1_UIDT-test.py
+++ b/simulation/UIDTv3.6.1_UIDT-test.py
@@ -13,9 +13,6 @@ Synchronized with Manuscript v3.6.1:
 
 import mpmath
 
-# 80-dps Precision Enforcement (UIDT v3.9 S0-Rule)
-mpmath.mp.dps = 80
-
 # =============================================================================
 # I. CONSTANTS & TARGETS (v3.6.1 CLEAN STATE)
 # =============================================================================
@@ -43,6 +40,9 @@ def solve_canonical_parameters():
     Solves the system of 3 equations based on v3.6.1 specifications.
     Derives m_S, kappa, and lambda_S consistent with the Mass Gap.
     """
+    # 80-dps Precision Enforcement (UIDT v3.9 S0-Rule) - LOCAL SCOPE
+    mpmath.mp.dps = 80
+
     print("\n🔍 UIDT PARAMETER SOLVER (v3.6.1 Logic)")
     print("="*40)
     
@@ -93,6 +93,9 @@ def solve_canonical_parameters():
 # III. MAIN PROGRAM
 # =============================================================================
 if __name__ == "__main__":
+    # 80-dps Precision Enforcement (UIDT v3.9 S0-Rule) - LOCAL SCOPE
+    mpmath.mp.dps = 80
+
     # 1. Determine Parameters
     params = solve_canonical_parameters()
     


### PR DESCRIPTION
This PR implements a critical code health remediation (S0-Rule) for the UIDT framework. It migrates the `simulation/UIDTv3.6.1_UIDT-test.py` script from standard FP64 floating-point math (via `numpy` and `scipy`) to 80-decimal-place precision using the `mpmath` library.

### Changes:
- **Precision Enforcement:** Set `mpmath.mp.dps = 80` as per UIDT v3.9 requirements.
- **Library Migration:** Replaced `scipy.optimize.fsolve` with `mpmath.findroot` for solving canonical parameter systems.
- **Signature Refactoring:** Updated the `equations` objective function to a multi-argument signature compatible with `mpmath` solvers.
- **Precision Closure:** All physical constants are now initialized using string-to-mpf conversion to avoid float rounding errors.
- **Cleanup:** Removed unused `physical_constants` import and all `numpy` dependencies.

**Note:** This is a "Blind Refactoring" performed in an airgapped environment where the necessary libraries were unavailable for local execution. The logic follows `mpmath` system-solver specifications and UIDT mathematical determinism laws.

---
*PR created automatically by Jules for task [14431386959653540206](https://jules.google.com/task/14431386959653540206) started by @badbugsarts-hue*