### PR TITLE
[UIDT-v3.9] chore(verification): remove unused `import time` from ergodicity_check.py

### DIFF
--- a/verification/scripts/ergodicity_check.py
+++ b/verification/scripts/ergodicity_check.py
@@ -1,7 +1,6 @@
 import sys
 import os
 import numpy as np
-import time
 from scipy.linalg import expm
 
 # Add the path to the simulation script


### PR DESCRIPTION
## 🎯 What
Removed unused `import time` from
`verification/scripts/ergodicity_check.py` (line 4).

## 💡 Why
Unused imports reduce readability and trigger linter warnings.
This import was never referenced in the script body.
No physics logic is affected.

## ✅ Verification
- `py_compile`: PASS
- No `float()` introduced
- No mpmath / `mp.dps` changes
- No Ledger constants affected
- No deletion > 10 lines in `/core` or `/modules`
- RG constraint: unaffected

## ✨ Result
Clean import block. Linter silent on this file.

## Affected Constants
None.

## Claims Table
| Claim ID | Category | Source |
|---|---|---|
| N/A — no physical claim | — | Code hygiene only |

## Reproduction Note
```bash
python -m py_compile verification/scripts/ergodicity_check.py
```

---
*PR created automatically by Jules for task [4186615842528220399](https://jules.google.com/task/4186615842528220399) started by @badbugsarts-hue*