### PR TITLE
🔒 Fix Git argument injection in framework integrity audit

### DIFF
--- a/verification/audits/framework_integrity_audit.py
+++ b/verification/audits/framework_integrity_audit.py
@@ -284,6 +284,8 @@ def _utc_now_iso() -> str:
 
 
 def _run_git(repo_root: Path, args: list[str]) -> str:
+    # Security: Use a list for subprocess.run to avoid shell injection.
+    # Callers should use the "--" separator where appropriate to prevent argument injection.
     p = subprocess.run(
         ["git", "--no-pager", *args],
         cwd=str(repo_root),
@@ -602,7 +604,7 @@ def main() -> int:
     head = _run_git(repo_root, ["rev-parse", "HEAD"])
     short = _run_git(repo_root, ["rev-parse", "--short", "HEAD"])
     try:
-        last_tag = _run_git(repo_root, ["describe", "--tags", "--abbrev=0"])
+        last_tag = _run_git(repo_root, ["describe", "--tags", "--abbrev=0", "--"])
     except Exception:
         last_tag = ""
 
@@ -1282,7 +1284,7 @@ def main() -> int:
             }
         )
     try:
-        commits_raw = _run_git(repo_root, ["log", f"{last_tag}..HEAD", "--oneline", "--decorate", "-n", "200"])
+        commits_raw = _run_git(repo_root, ["log", "--oneline", "--decorate", "-n", "200", "--", f"{last_tag}..HEAD"])
     except Exception:
         commits_raw = ""
     if commits_raw:


### PR DESCRIPTION
🎯 **What:** Fixed an argument injection vulnerability in the `_run_git` function within `verification/audits/framework_integrity_audit.py`.

⚠️ **Risk:** The vulnerability allowed malicious repository metadata, such as specially crafted tag names starting with a hyphen (e.g., `--output=/tmp/pwned`), to inject command-line options into `git` subcommands. This could lead to arbitrary file writes or potentially arbitrary code execution.

🛡️ **Solution:**
1.  Updated the `_run_git` function with security documentation regarding safe subprocess usage.
2.  Modified call sites for `git log` and `git describe` to use the `--` separator, which explicitly terminates the list of options and ensures that subsequent arguments are treated as positional parameters (references or paths).
3.  Ensured that the revision range in `git log` is passed after the `--` separator.

---
*PR created automatically by Jules for task [1218900553141929299](https://jules.google.com/task/1218900553141929299) started by @badbugsarts-hue*