### PR TITLE
[UIDT-v3.9] Docs: Recalibrate README hierarchy and documentation index

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,27 +43,33 @@
 
 ---
 
-<div align="center">
+## Documentation Index
 
-### THE UNIVERSAL MASS GAP CONSTANT
+### Canonical entry points
+- [`README.md`](./README.md) — repository overview and claim hierarchy
+- [`FORMALISM.md`](./FORMALISM.md) — formalism snapshot
+- [`GLOSSARY.md`](./GLOSSARY.md) — terminology
+- [`LEDGER/`](./LEDGER) — immutable parameter and claim ledger
+- [`manuscript/`](./manuscript) — manuscript source of truth
+- [`verification/`](./verification) — reproducibility and verification scripts
 
-# $\Delta^*$
+### Recommended technical documents
+- [`docs/bare_gamma_theorem.md`](./docs/bare_gamma_theorem.md)
+- [`docs/cosmological_implications_v3.9.md`](./docs/cosmological_implications_v3.9.md)
+- [`docs/falsification-criteria.md`](./docs/falsification-criteria.md)
+- [`docs/evidence-classification.md`](./docs/evidence-classification.md)
+- [`docs/experimental_roadmap.md`](./docs/experimental_roadmap.md)
+- [`docs/PR_Review_Protocol_v2.0.md`](./docs/PR_Review_Protocol_v2.0.md)
+- [`docs/citation-guide.md`](./docs/citation-guide.md)
+- [`docs/data-availability.md`](./docs/data-availability.md)
+- [`docs/README.md`](./docs/README.md) — documentation landing page
 
-<div style="background: #f6f8fa; border: 1px solid #d0d7de; border-radius: 6px; padding: 20px; font-family: 'Courier New', monospace; font-size: 11px; word-break: break-all; text-align: left; max-width: 800px; margin: 0 auto; color: #24292f; box-shadow: 0 4px 12px rgba(0,0,0,0.05);">
-<strong>1.710035046742213182020771096611622363294044242291085581231747999663464376395570369445002815542192033041630851992293577578337148116022890290326969033792718321530044021016130813146135502941908808474427620022069439336733684080990670841868721862693239644</strong>
-</div>
-
-### GeV
-
-*(Established analytic precision limit $\mathcal{O}(10^{-280})$)*
-
-<br>
-
-[![Banach Convergence](https://github.com/Mass-Gap/UIDT-Framework-v3.9-Canonical/blob/main/figures/supplementary/uidt_visualize1.png?raw=true)](https://github.com/Mass-Gap/UIDT-Framework-v3.9-Canonical/blob/main/figures/supplementary/uidt_visualize1.png?raw=true)
-
-**Figure 1:** Algorithmic proof of non-perturbative mass generation. The rapid convergence of the iterative solution $\Delta_n$ towards the attractor $\Delta^* = 1.710$ GeV demonstrates the unique existence of a stable vacuum state.
-
-</div>
+### Audit trail
+- [`docs/critical_review_2025.md`](./docs/critical_review_2025.md)
+- [`docs/epistemic_audit_2026-03-30.md`](./docs/epistemic_audit_2026-03-30.md)
+- [`docs/first_principles_evidence_audit_2026-03-30.md`](./docs/first_principles_evidence_audit_2026-03-30.md)
+- [`docs/archive/`](./docs/archive)
+- [`docs/archival-notes/`](./docs/archival-notes)
 
 ---
 
@@ -204,44 +210,6 @@ Executes the Four-Pillar Verification Suite (v3.9).
 
 ```bash
 python verification/scripts/UIDT_Master_Verification.py
-```
-
-**Expected Output (v3.9):**
-
-```text
-╔══════════════════════════════════════════════════════════════╗
-║  UIDT v3.9 MASTER VERIFICATION SUITE (Hybrid Engine)         ║
-║  Strategies: Scipy Solver + Mpmath High-Precision Prover     ║
-╚══════════════════════════════════════════════════════════════╝
-
-[1] RUNNING NUMERICAL SOLVER (System Consistency)...
-   > Solution Found: m_S=1.7050, kappa=0.5001
-   > System Status: ✅ CLOSED
-
-[2] EXECUTING HIGH-PRECISION PROOF (80 Digits)...
-   > Banach Fixed Point: 1.710035046742213182... GeV
-   > Vacuum Energy:      2.447165543834107377... GeV^4
-   > THEOREM 3.4: ✅ PROVEN (Existence & Uniqueness)
-
-[3] PILLAR II: DERIVING MISSING LINK (Lattice Topology)...
-   > Geometry Base: 104.66 MeV
-   > Torsion Energy (E_T): 2.44 MeV
-   > Vacuum Resonance (f_vac): 107.10 MeV
-
-[4] PILLAR III: SPECTRAL EXPANSION & PREDICTIONS...
-   > X17 Noise Floor: 17.10 MeV
-   > X2370 Resonance: 2.370 GeV
-
-[5] PILLAR IV: PHOTONIC APPLICATION (Metamaterials, Category D)...
-   > Critical Refractive Index (n): 16.3390
-```
-
-**2. Containerized Audit**
-Run the Master Verification Suite in a completely isolated environment:
-
-```bash
-docker build -t uidt-verify-v3.9 .
-docker run uidt-verify-v3.9
 ```
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,133 +1,40 @@
-# UIDT Framework Documentation Index
+# UIDT v3.9 Documentation
 
-**Version:** 3.9  
-**DOI:** 10.5281/zenodo.17835200  
-**Maintainer:** P. Rietz (ORCID: 0009-0007-4307-1609)
+This directory contains supporting technical documentation, audits, and archival notes for the canonical UIDT v3.9 repository.
 
-## Quick Navigation
+## Canonical entry points
 
-### 📐 Foundations (Mathematical Proofs - Clay Math Relevant)
-- [Bare Gamma Theorem](foundations/bare_gamma_theorem.md) - γ = 16.339 calibration [A-]
-- [SU(3) Gamma Conjecture Audit](foundations/su3_gamma_conjecture_audit.md) - RG fixed point analysis
-- [SU(3) Gamma Proof Sketch](foundations/su3_gamma_proof_sketch.md) - 5κ² = 3λ_S constraint
-- [Gribov-Cheeger Proof](foundations/gribov_cheeger_proof.md) - Topological quantization
-- [GNS Hilbert Construction](foundations/gns_hilbert_construction.md) - Operator algebra
-- [Kugo-Ojima Criterion](foundations/kugo_ojima_criterion.md) - Confinement mechanism
-- [CE8 Derivation](foundations/CE8_derivation.md) - Exceptional Lie algebra connection
-- [Factor 2.3 Derivation](foundations/Factor_2_3_Derivation.md) - Vacuum energy residual [L3]
-- [Torsion Self-Energy](foundations/Torsion_Self_Energy.md) - E_T = 2.44 MeV lattice binding
-- [Ghost Sector Lagrangian](foundations/ghost_sector_lagrangian.md) - BRST cohomology
-- [SI Lagrangian Corrections](foundations/si_lagrangian_corrections.md) - Higher-order terms
+- Root overview: [`../README.md`](../README.md)
+- Formal manuscript source of truth: `manuscript/`
+- Verification runners and scripts: `verification/`
+- Immutable parameter ledger: `LEDGER/`
+- Canonical formalism snapshot: `FORMALISM.md`
 
-### ⚛️ QCD & Lattice (CERN/FLAG/ILDG Relevant)
-- [QCD Derivation](qcd-lattice/derivation_qcd.md) - Yang-Mills spectral gap
-- [Schwinger-Dyson Propagator](qcd-lattice/schwinger_dyson_propagator.md) - Self-energy equations
-- [Wilson Loop String Tension](qcd-lattice/wilson_loop_string_tension.md) - Confinement observable
-- [Spectral Function Positivity](qcd-lattice/spectral_function_positivity.md) - Källén-Lehmann representation
-- [RG 2-Loop Beta](qcd-lattice/rg_2loop_beta.md) - Renormalization group flow
-- [RG Beta Derivation Gamma](qcd-lattice/rg_beta_derivation_gamma.md) - γ from RG equations
-- [N_dof Phase Transition](qcd-lattice/ndof_phase_transition.md) - Degrees of freedom evolution
-- [Holographic BH-YM Correspondence](qcd-lattice/holographic_bh_ym_correspondence.md) - AdS/CFT connection
-- [MCMC Bayesian Calibration](qcd-lattice/mcmc_bayesian_calibration.md) - Parameter estimation
+## Recommended active documents
 
-### 🔬 Predictions (Experimental - LHC/DESI)
-- [Glueball Spectrum Predictions](predictions/glueball_spectrum_predictions.md) - f₀(1710) retracted [E]
-- [Heavy Quark Predictions](predictions/heavy_quark_predictions.md) - Charm and bottom masses
-- [Quark Mass Hierarchy Prediction](predictions/quark_mass_hierarchy_prediction.md) - Generation scaling
-- [LHC Predictions: Drell-Yan](predictions/lhc_predictions_drell_yan.md) - High-energy cross sections
-- [LHCb Predictions Paper Draft](predictions/lhcb_predictions_paper_draft.md) - B-physics observables
-- [DESI DR2 Alignment Report](predictions/DESI_DR2_alignment_report.md) - Cosmology validation
-- [Cosmological Unification v3.9](predictions/Cosmological_Unification_v3.9.md) - H₀, Ω_m, w₀ predictions
-- [Cosmological Implications v3.9](predictions/cosmological_implications_v3.9.md) - DESI/JWST/ACT alignment
-- [Generation Scaling v3.9](predictions/Generation_Scaling_v3.9.md) - Quark mass hierarchy
-- [Emergent Geometry Section 7](predictions/emergent_geometry_section7.md) - Geometric operator construction
-- [v Parameter Tension Note](predictions/v_parameter_tension_note.md) - v = 47.7 MeV calibration
+### Core scientific status
+- [`bare_gamma_theorem.md`](./bare_gamma_theorem.md)
+- [`cosmological_implications_v3.9.md`](./cosmological_implications_v3.9.md)
+- [`falsification-criteria.md`](./falsification-criteria.md)
+- [`evidence-classification.md`](./evidence-classification.md)
+- [`experimental_roadmap.md`](./experimental_roadmap.md)
 
-### 📋 Governance (Quality & Standards)
-- [Evidence Classification System](governance/evidence-classification.md) - Categories A through E
-- [Falsification Criteria](governance/falsification-criteria.md) - L1-L6 limitations and kill-switches
-- [Limitations](governance/limitations.md) - Known issues L1-L6
-- [Reproduction Protocol](governance/reproduction-protocol.md) - One-command reproducibility
-- [Verification Guide](governance/verification-guide.md) - 80-digit precision testing
-- [Data Availability](governance/data-availability.md) - All simulation and verification data
-- [Citation Guide](governance/citation-guide.md) - How to cite UIDT
-- [Core Baseline Protocol](governance/core-baseline-protocol.md) - Regression testing
-- [PR Review Protocol v2.0](governance/PR_Review_Protocol_v2.0.md) - Quality gates A-G
-- [Experimental Roadmap](governance/experimental_roadmap.md) - Future validation plans
-- [Theory Comparison](governance/theory_comparison.md) - UIDT vs. alternatives
-- [Theoretical Notes](governance/theoretical_notes.md) - General framework overview
+### Governance and review
+- [`PR_Review_Protocol_v2.0.md`](./PR_Review_Protocol_v2.0.md)
+- [`citation-guide.md`](./citation-guide.md)
+- [`data-availability.md`](./data-availability.md)
 
-### 🔍 Audits (Epistemic Quality Control)
-- [Epistemic Audit 2026-03-30](audits/epistemic_audit_2026-03-30.md) - Evidence category review
-- [First Principles Evidence Audit 2026-03-30](audits/first_principles_evidence_audit_2026-03-30.md) - Derivation validation
-- [Gamma First Principles Crosscheck 2026-03-30](audits/gamma_first_principles_crosscheck_2026-03-30.md) - γ = 16.339 audit
-- [Schwinger Mechanism Deep Research 2026-03-30](audits/schwinger_mechanism_deep_research_2026-03-30.md) - Confinement analysis
-- [Critical Review 2025](audits/critical_review_2025.md) - Framework limitations
-- [Systematic Robustness Report](audits/systematic_robustness_report.md) - Stability analysis
-- [Test Results v3.9.0](audits/test_results_v3.9.0.md) - Verification suite output
+### Audits and review history
+- [`critical_review_2025.md`](./critical_review_2025.md)
+- [`epistemic_audit_2026-03-30.md`](./epistemic_audit_2026-03-30.md)
+- [`first_principles_evidence_audit_2026-03-30.md`](./first_principles_evidence_audit_2026-03-30.md)
 
-### Subdirectories
-- [archival-notes/](archival-notes/) - Historical development notes
-- [archive/](archive/) - Deprecated or superseded documents
-- [qa/](qa/) - Quality assurance reports and PR reviews
-- [research/](research/) - Ongoing research and exploratory work
+## Archived material
 
-## Evidence Categories
+Superseded or historical notes are retained in:
+- [`archive/`](./archive/)
+- [`archival-notes/`](./archival-notes/)
 
-All quantitative claims in UIDT are tagged with evidence categories:
+## Scope note
 
-| Category | Name | Threshold |
-|----------|------|-----------|
-| **[A]** | Mathematically Proven | Residual < 10⁻¹⁴ |
-| **[A-]** | Phenomenologically Determined | Calibrated, permanent |
-| **[B]** | Lattice QCD Consistent | z ≈ 0.37σ |
-| **[C]** | Calibrated | DESI/JWST/ACT data |
-| **[D]** | Predicted | Unconfirmed |
-| **[E]** | Withdrawn/Speculative | Retracted |
-
-## Known Limitations
-
-- **L1:** 10¹⁰ geometric factor - UNEXPLAINED
-- **L2:** Electron mass - 23% residual
-- **L3:** Vacuum energy - factor 2.3 residual
-- **L4:** γ = 16.339 - NOT derived from RG first principles [A-]
-- **L5:** N = 99 RG steps - empirically chosen
-- **L6:** Glueball f₀(1710) - RETRACTED [E] since 2025-12-25
-
-## Contributing
-
-See [CONTRIBUTING.md](../CONTRIBUTING.md) in the repository root for guidelines on:
-- Evidence classification requirements
-- Numerical precision standards (mp.dps = 80)
-- PR review protocol
-- Anti-tampering rules
-
-## File System Laws (Extended)
-
-This documentation structure enforces the following File System Laws:
-
-### Original Laws (L-FS-01 through L-FS-10)
-See the repository's file structure governance documentation.
-
-### Extended Laws for External Research Compatibility
-
-| Law | Description | Rationale |
-|-----|-------------|-----------|
-| **L-FS-11** | **External Metadaten-Pflicht**: Every publication-relevant directory (`clay-submission/`, `manuscript/`, `docs/`) must contain `metadata.yaml` or `codemeta.json` with Dublin-Core-compatible fields. | HAL/Zenodo/CDS interoperability |
-| **L-FS-12** | **Reproduzierbarkeits-Manifest**: Every directory with verification/simulation code must contain a `reana.yaml`-compatible workflow description or at minimum a `REPRODUCE.md`. | CERN CAP/REANA compatibility |
-| **L-FS-13** | **Docs-Taxonomie**: `docs/` follows a four-layer taxonomy: `foundations/`, `qcd-lattice/`, `predictions/`, `governance/`, `audits/`. | FLAG-Review compatibility, reviewer orientation |
-
-### Compliance Status
-
-- ✅ **L-FS-11:** `docs/metadata.yaml` and `clay-submission/metadata.yaml` created (Dublin Core)
-- ✅ **L-FS-12:** `clay-submission/REPRODUCE.md` created (REANA-compatible)
-- ✅ **L-FS-13:** Four-layer taxonomy implemented (50+ documents organized)
-
-## License
-
-See [LICENSE.md](../LICENSE.md) in the repository root.
-
----
-**Last Updated:** 2026-04-06  
-**Framework Version:** 3.9  
-**Total Documents:** 50+
+This directory is subordinate to the root `README.md`. If any summary in `docs/` diverges from canonical claims in the manuscript, ledger, or root-level governance files, the root-level source prevails.


### PR DESCRIPTION
## Summary

Recalibrates the documentation hierarchy between root `README.md` and `docs/README.md`.

## Changes

- rewrites `docs/README.md` into a true documentation landing page
- adds a `Documentation Index` section to the root `README.md`
- explicitly links `docs/PR_Review_Protocol_v2.0.md` and `docs/bare_gamma_theorem.md`
- clarifies that `docs/` is subordinate to root-level canonical sources

## Claims Table

| ID | Category | Source |
|---|---|---|
| C1 | Structural documentation change | root `README.md` |
| C2 | Structural documentation change | `docs/README.md` |
| C3 | No scientific claim changed | repository content unchanged outside README layer |

## Reproduction Note

```bash
git checkout docs/recalibrate-readme-TKT-20260418
git diff main -- README.md docs/README.md
```

## DOI/arXiv resolvability

No new DOI/arXiv claim introduced in this PR.

## Affected constants

None.
