### PR TITLE
[UIDT-v3.9] manuscript: Isotopic Torsion Doubling Down-Quark Mass (C <- B+D)

### DIFF
--- a/docs/theoretical_notes.md
+++ b/docs/theoretical_notes.md
@@ -281,7 +281,7 @@ Die **neuesten JWST-Daten der CCHP-Gruppe (Freedman)** stützen den UIDT-Wert vo
 
 ---
 
-## 9. QED Mass Correction for Down-Quark
+## 10. QED Mass Correction for Down-Quark
 
 **Status:** Formal Resolution of Isotopic Doubling
 **Classification:** **Category B** (Topology) / **Category D** (QED Correction)
@@ -299,12 +299,12 @@ $$ \Delta m_{EM} \approx -0.18 \text{ MeV} $$
 
 ### Result
 $$ m_d = 4.88 - 0.18 = 4.70 \text{ MeV} $$
-This creates exact agreement with the PDG consensus ($\sigma < 0.1$), eliminating the need for free Yukawa parameters for the down quark.
+The QED self-energy correction ($\Delta m_{EM} \approx -0.18$ MeV) is a Category D theoretical hypothesis. If valid, it suggests compatibility with the PDG value. The residual cannot be claimed as eliminated without an ab-initio derivation of $\Delta m_{EM}$ from the UIDT Lagrangian.
 
 
 ---
 
-## 10. The Geometrical Necessity of wa: From Bare Gamma to DESI-DR2 (PR #82)
+## 11. The Geometrical Necessity of wa: From Bare Gamma to DESI-DR2 (PR #82)
 
 **Status:** Theoretical Prediction
 **Classification:** **Category C** (L-dependent derivation, see S1-01), **Category C** (Observation Comparison)
@@ -414,7 +414,7 @@ This value is **proposed** as an alternative baseline, pending independent verif
 
 ---
 
-## 13. QED Mass Correction for Up-Quark (FLAG 2024 Alignment) (PR #61)
+## 14. QED Mass Correction for Up-Quark (FLAG 2024 Alignment) (PR #61)
 
 **Status:** Consistent [C] (0.75σ)
 **Classification:** **Category C** (Calibrated Observation)
@@ -488,7 +488,7 @@ This correlation is strictly classified as **Evidence Category D**. It represent
 
 ---
 
-## 14. Hubble-Patch Meta-Analysis
+## 15. Hubble-Patch Meta-Analysis
 
 **Status:** Under Active Review
 **Classification:** **Category C** (Calibrated Observation)
@@ -505,7 +505,7 @@ Therefore, UIDT does not *solve* the crisis in absolute terms; rather, it *offer
 
 **Falsification Warning:** This prediction crucially depends on forthcoming data from JWST DR3 (2027) and Euclid DR1. If these upcoming surveys conclusively drift away from the $70.4$ target (e.g., locking strictly to $\Lambda$CDM and late-universe deviations disappear), this would constitute a falsification of the UIDT late-universe topological projection. Future local distance ladder calibrations must be rigorously monitored.
 
-## 14. Topological Lepton Flavor Universality Violation (LFUV) Hypothesis
+## 16. Topological Lepton Flavor Universality Violation (LFUV) Hypothesis
 
 **Status:** Under Active Investigation
 **Classification:** **Category D** (Phenomenological Fit / Theoretical Hypothesis)

--- a/manuscript/UIDT_v3.9-Complete-Framework.tex
+++ b/manuscript/UIDT_v3.9-Complete-Framework.tex
@@ -684,6 +684,12 @@ Thermodynamically, $E_T$ represents the entropic tension that stabilizes the dis
 \noindent\textbf{Physical Manifestation (The Up-Quark Identification):}
 Crucially, this torsion energy $E_T \approx 2.44\,\MeV$ corresponds phenomenologically to the \emph{bare up-quark mass} $m_u$. The Particle Data Group (2024) reports the up-quark mass at the scale $\mu = 2\,\GeV$ as $m_u = 2.16^{+0.49}_{-0.26}\,\MeV$~\cite{PDG2024}. The geometric torsion value $2.44\,\MeV$ lies centrally within this $1\sigma$ confidence interval ($1.90$--$2.65\,\MeV$). This suggests that the ``bare mass'' of the lightest quark species may physically originate from the lattice torsion energy required to stabilize the vacuum geometry against collapse \textcolor{catC}{\textbf{[Evidence Category C]}}. The geometric derivation of $E_T$ itself remains \textcolor{catB}{\textbf{[Evidence Category B]}}.
 
+Furthermore, this mechanism suggests a topological rationale for the $u$-$d$ quark mass hierarchy without invoking arbitrary Yukawa parameters. Through \textbf{Isotopic Torsion Doubling} \textcolor{catB}{\textbf{[Evidence Category B]}}, the topological doubling of the vacuum torsion energy yields the down-quark mass approximation:
+\begin{equation}
+    m_d \approx E_{T,iso} = 2 \times E_T \approx 4.88\,\MeV.
+\end{equation}
+The topological prediction leaves a $+0.18\,\MeV$ ($2.58\sigma$) residual compared to the PDG 2024 $\overline{MS}$ value at $\mu = 2\,\GeV$ ($m_d = 4.70 \pm 0.07\,\MeV$). The QED self-energy correction ($\Delta m_{EM} \approx -0.18\,\MeV$) is a \textcolor{catD}{\textbf{[Category D theoretical hypothesis]}}. If valid, it suggests compatibility with the PDG value, however the residual cannot be claimed as eliminated without an ab-initio derivation of $\Delta m_{EM}$ from the UIDT Lagrangian.
+
 \noindent\textbf{Code Audit Note:} This relation is audited by \texttt{modules/lattice\_topology.py} (\texttt{TorsionLattice.calculate\_vacuum\_frequency()}) [Data Repository].
 
 \section{Constructive Derivation of the Yang-Mills Mass Gap}


### PR DESCRIPTION
1. Verified manuscript/UIDT_v3.9-Complete-Framework.tex did not contain the Isotopic Torsion Doubling block.
2. Inserted the required block in the manuscript under "The Up-Quark Identification".
3. Removed banned language ("exact agreement", "eliminating") from `docs/theoretical_notes.md` to properly frame the QED correction as a Category D Hypothesis with a 2.58 sigma residual.
4. Corrected the duplicate "Section 9" / "Section 14" numbers in `docs/theoretical_notes.md`.

---
*PR created automatically by Jules for task [12461400825490586271](https://jules.google.com/task/12461400825490586271) started by @badbugsarts-hue*