### PR TITLE
[UIDT-v3.9] fix: PI D12+D15 — L1 ill-defined, E_T 4.0σ PDG 2025, χ_top Dürr 2025

### DIFF
--- a/CANONICAL/LIMITATIONS.md
+++ b/CANONICAL/LIMITATIONS.md
@@ -7,18 +7,25 @@
 
 ## Active Limitations (Unresolved)
 
-### L1: 10¹⁰ Geometric Factor
-**Status:** 🔬 HIGHEST PRIORITY
+### L1: Geometric Scale Factor (Ill-Defined)
+**Status:** 🔬 HIGHEST PRIORITY — PROBLEM STATEMENT REQUIRES CLARIFICATION
 
 **Description:**  
-The ratio λ_UIDT / λ_theoretical involves a factor of ~10¹⁰ that lacks first-principles derivation.
+Previous versions stated "a factor of ~10¹⁰" without specifying reference scales.
+mpmath 80-dps analysis (TKT-20260416-L1L4L5-analysis.md) reveals:
+
+  λ_UIDT / r_conf = 0.660 nm / 0.197 fm = 3.35 × 10⁶ ≈ 10^6.5 (NOT 10¹⁰)
+
+The actual ratio depends on which UV/IR scales are compared. No energy ratio
+in the Standard Model yields exactly 10¹⁰. Closest approach: λ_UIDT/r_conf ≈ α⁻³ × 1.302.
 
 **Impact:**  
 - λ_UIDT calibrated [C] instead of derived [A]
-- Undermines claim of "parameter-free" theory
+- The problem is real but was previously ill-defined
 
 **Condition for Resolution:**  
-Derive geometric factor from fundamental principles (topology, holography, etc.)
+1. Precisely define which UV and IR scales are compared
+2. Derive the geometric factor from first principles (topology, holography, or α⁻³ connection)
 
 ---
 
@@ -161,7 +168,7 @@ Corrected to v = 47.7 MeV. Old value was erroneous.
 
 | ID      | Limitation                          | Impact on Claims              | Priority    |
 |---------|--------------------------------------|-------------------------------|-------------|
-| L1      | 10¹⁰ factor                         | λ_UIDT [C→D if unresolved]    | 🔴 High     |
+| L1      | Geometric scale (~10^6.5, ill-defined)| λ_UIDT [C→D if unresolved]    | 🔴 High     |
 | L2      | Electron mass                        | m_e formula approximate       | 🟡 Medium   |
 | L3      | Vacuum energy                        | ρ_vac factor 2.3              | 🟢 Accepted |
 | L4      | γ not from RG                        | γ remains [A-] not [A]        | 🔴 High     |

--- a/LEDGER/CLAIMS.json
+++ b/LEDGER/CLAIMS.json
@@ -533,7 +533,7 @@
       "confidence": 0.60,
       "dependencies": ["UIDT-C-001", "UIDT-C-002", "UIDT-C-044", "UIDT-C-048"],
       "since": "v3.9",
-      "notes": "Multiplicative rules lack first-principles derivation. M(u)=2.44 has 3.75σ FLAG tension (pre-QED). NO uncertainties stated. NOT [B]: fails z<1σ. Source: quark_mass_hierarchy_prediction.md, theoretical_notes.md §7,§9,§13.",
+      "notes": "Multiplicative rules lack first-principles derivation. M(u)=2.44 has 4.0σ PDG 2025 tension (m_u=2.16±0.07 MeV, pre-QED). NO uncertainties stated. NOT [B]: fails z<1σ. Source: quark_mass_hierarchy_prediction.md, theoretical_notes.md §7,§9,§13.",
       "falsification": "If M(d)/M(u)≠2.0 at >3σ, or M(s) deviates from 93.81 MeV by >10%."
     },
     {
@@ -614,7 +614,7 @@
       "confidence": 0.55,
       "dependencies": ["UIDT-C-054", "UIDT-C-055"],
       "since": "v3.9.6",
-      "notes": "SVZ leading-order estimate. TENSION ALERT: z ≈ 8–10σ vs quenched lattice (185–191 MeV). NLO corrections expected +30–80%. Previous erroneous values: 55 MeV (wrong formula, PR #190), 107 MeV (partial). Corrected to 142.98 MeV via mpmath 80-dps verification (PR #213, chi_top_formula_audit.md). Under the IR/EFT reframing (v3.9.7), this tension is interpreted as evidence for missing NLO anomalous-dimension corrections in the SVZ operator and RG-flow truncation errors at scale μ ∼ Δ*. This does NOT affect the Category-A spectral gap Δ* or the Category-A- coupling γ. See UIDT-C-096 (NLO research programme). TENSION ALERT remains active until NLO result available.",
+      "notes": "SVZ leading-order estimate. TENSION ALERT: z ≈ 19.7σ (LO), z ≈ 4.2σ (NLO×1.3023) vs quenched lattice (198.1 ± 2.8 MeV, Dürr et al. 2025, arXiv:2501.08217). NLO corrections expected +30–80%. Previous erroneous values: 55 MeV (wrong formula, PR #190), 107 MeV (partial). Corrected to 142.98 MeV via mpmath 80-dps verification (PR #213, chi_top_formula_audit.md). Under the IR/EFT reframing (v3.9.7), this tension is interpreted as evidence for missing NLO anomalous-dimension corrections in the SVZ operator and RG-flow truncation errors at scale μ ∼ Δ*. This does NOT affect the Category-A spectral gap Δ* or the Category-A- coupling γ. See UIDT-C-096 (NLO research programme). TENSION ALERT remains active until NLO result available.",
       "falsification": "NLO-corrected value outside [140, 220] MeV refutes SVZ estimate applicability."
     },
     {

--- a/docs/falsification-criteria.md
+++ b/docs/falsification-criteria.md
@@ -243,7 +243,7 @@ Comparison with quenched SU(3) lattice QCD measurements of χ_top^{1/4}
 If the fully NLO-corrected χ_top^{1/4} falls **outside** the range [140, 220] MeV → **SVZ ESTIMATE INAPPLICABLE**
 
 **Current Status:**
-⚠️ **TENSION** — UIDT SVZ LO: 143 MeV vs quenched lattice: 185–191 ± 5 MeV (z ≈ 8–10σ)
+⚠️ **TENSION** — UIDT SVZ LO: 143 MeV vs quenched lattice: 198.1 ± 2.8 MeV (Dürr et al. 2025, arXiv:2501.08217) (z ≈ 19.7σ (LO), z ≈ 4.2σ (NLO×1.3023))
 
 **Timeline:**
 - **2026:** NLO corrections to SVZ estimate (+30–80% expected)


### PR DESCRIPTION
PI Decisions D12+D15. 3 files, surgical edits.

DOI: 10.5281/zenodo.17835200