### PR TITLE
[UIDT-v3.9] fix: C-044 tension 3.75σ→4.0σ PDG 2025 (D15 completion)

### DIFF
--- a/LEDGER/CLAIMS.json
+++ b/LEDGER/CLAIMS.json
@@ -474,7 +474,7 @@
       "confidence": 0.70,
       "dependencies": ["UIDT-C-001", "UIDT-C-002", "UIDT-C-048"],
       "since": "v3.9",
-      "notes": "E_T = f_vac − Δ/γ = 107.10 − 104.66 MeV. Shows 3.75σ tension with FLAG 2024 m_u=2.14±0.08 MeV (pre-QED correction). After QED: m_u^phys≈2.08 MeV (0.75σ). NOT [B]: z=3.75σ fails B threshold. Upgraded [D]→[C] per PR #216 (A5, 2026-04-06): composite scaling-limit parameter. CONSTANTS.md v3.9.5 authoritative. Source: theoretical_notes.md §7,§13.",
+      "notes": "E_T = f_vac − Δ/γ = 107.10 − 104.66 MeV. Shows 4.0σ tension with PDG 2025 m_u=2.16±0.07 MeV (pre-QED correction). After QED: m_u^phys≈2.08 MeV (0.75σ). NOT [B]: z=4.0σ fails B threshold. Upgraded [D]→[C] per PR #216 (A5, 2026-04-06): composite scaling-limit parameter. CONSTANTS.md v3.9.5 authoritative. Source: theoretical_notes.md §7,§13.",
       "falsification": "If lattice QCD excludes 2.44 MeV bare torsion at >5σ, E_T is refuted."
     },
     {


### PR DESCRIPTION
Completes D15. C-044 was missed in PR #340.

DOI: 10.5281/zenodo.17835200