### PR TITLE
⚙️ [ci] Add automated LaTeX build workflow for manuscript validation. (TKT-2026-04-19)

### DIFF
--- a/.github/workflows/latex_build_check.yml
+++ b/.github/workflows/latex_build_check.yml
@@ -1,0 +1,36 @@
+name: LaTeX Build Check
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  push:
+    paths:
+      - 'manuscript/**/*.tex'
+  pull_request:
+    paths:
+      - 'manuscript/**/*.tex'
+
+jobs:
+  build_latex:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install TeX Live
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y texlive-latex-extra texlive-science texlive-bibtex-extra texlive-fonts-recommended
+
+      - name: Compile CSF_UIDT_Unification.tex
+        working-directory: manuscript
+        run: |
+          pdflatex -interaction=nonstopmode -halt-on-error CSF_UIDT_Unification.tex
+          # Optionally run a second time for references
+          pdflatex -interaction=nonstopmode -halt-on-error CSF_UIDT_Unification.tex
+
+      - name: Compile topological_quantization.tex
+        working-directory: manuscript
+        run: |
+          pdflatex -interaction=nonstopmode -halt-on-error topological_quantization.tex
+          pdflatex -interaction=nonstopmode -halt-on-error topological_quantization.tex

--- a/.github/workflows/latex_build_check.yml
+++ b/.github/workflows/latex_build_check.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   build_latex:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Adds a GitHub Actions workflow to run a daily and on-push `pdflatex` build test for `CSF_UIDT_Unification.tex` and `topological_quantization.tex` to ensure manuscript integrity and detect compiler errors such as undefined references.

---
*PR created automatically by Jules for task [2633287460413382574](https://jules.google.com/task/2633287460413382574) started by @badbugsarts-hue*