### PR TITLE
[UIDT-v3.9] Docs: Add Visualization Policy to best practices

### DIFF
--- a/best_practices.md
+++ b/best_practices.md
@@ -128,3 +128,20 @@ Reusable utilities and adapters:
   - Keep outputs reproducible; pin versions; avoid network access at runtime in tests
   - Tests must never reduce precision or mock mpmath
   - When adding modules, include local precision guard and invariant assertions for RG relations
+## Visualization Policy (Instructions for Jules)
+
+- **Elite Scientific Standards:** Whenever generating scientific visualizations, plots, or diagrams, act at the absolute top-tier, world-class level (Nature/Science publication standard).
+- **Epistemic Seriousness:** Visualizations must be highly evidential, strictly data-driven, and utterly serious. Avoid any decorative elements, 3D gimmicks, or visual clutter. Maximize information density (UIDT standard) and ensure perfect axes labeling, error bars, and methodological transparency.
+- **Strict Repository Placement (File System Laws):**
+  - Save raw plot data and verification visuals strictly in `verification/data/visualizations/` (never in `verification/scripts/` or root).
+  - Save publication-ready, finalized figures directly to `manuscript/figures/` or `docs/assets/`.
+  - **NEVER** save images or plots in the root directory, `UIDT-OS/**`, or any protected internal folders.
+
+## Visualization Policy (Instructions for Jules)
+
+- **Elite Scientific Standards:** Whenever generating scientific visualizations, plots, or diagrams, act at the absolute top-tier, world-class level (Nature/Science publication standard).
+- **Epistemic Seriousness:** Visualizations must be highly evidential, strictly data-driven, and utterly serious. Avoid any decorative elements, 3D gimmicks, or visual clutter. Maximize information density (UIDT standard) and ensure perfect axes labeling, error bars, and methodological transparency.
+- **Strict Repository Placement (File System Laws):**
+  - Save raw plot data and verification visuals strictly in `verification/data/visualizations/` (never in `verification/scripts/` or root).
+  - Save publication-ready, finalized figures directly to `manuscript/figures/` or `docs/assets/`.
+  - **NEVER** save images or plots in the root directory, `UIDT-OS/**`, or any protected internal folders.


### PR DESCRIPTION
This PR adds a strictly enforced "Visualization Policy" to the project's `best_practices.md` document, ensuring that any future scientific visualization meets elite publishing standards and adheres to rigid repository file system constraints.

### Details:
1. **Elite Standards:** Forces all generated plots to maximize information density and maintain Nature/Science-level rigor.
2. **Epistemic Seriousness:** Bans 3D gimmicks and decorative clutter in favor of methodological transparency and precision.
3. **File System Constraints:** Strictly routes raw visualization outputs to `verification/data/visualizations/` and final publication figures to `manuscript/figures/` or `docs/assets/`, effectively sandboxing the root and protected `/UIDT-OS/` pathways.

*(Note: The temporary ab-initio analysis script for Task 21 was generated, executed, validated against Planck/LiteBIRD criteria, and then deliberately not committed according to Sandbox-Isolation instructions).*

---
*PR created automatically by Jules for task [5783205629566386780](https://jules.google.com/task/5783205629566386780) started by @badbugsarts-hue*