### PR TITLE
fix(cosmology): purge unverified H0 artifacts and enforce Stratum II wording

### DIFF
--- a/LEDGER/CLAIMS.json
+++ b/LEDGER/CLAIMS.json
@@ -87,7 +87,7 @@
       "evidence": "C",
       "dependencies": ["DESI_DR2"],
       "since": "v3.7.2",
-      "notes": "Calibrated to DESI, NOT independent prediction"
+      "notes": "Calibrated to DESI, NOT independent prediction. Consistent with CCHP (2025) but underlying Hubble tension remains unresolved."
     },
     {
       "id": "UIDT-C-009",
@@ -307,7 +307,7 @@
       "confidence": 0.9,
       "dependencies": [],
       "since": "v3.7.2",
-      "notes": "DESI DR2 calibrated"
+      "notes": "DESI DR2 calibrated. Hubble tension remains unresolved."
     },
     {
       "id": "UIDT-C-030",

--- a/docs/falsification-criteria.md
+++ b/docs/falsification-criteria.md
@@ -216,7 +216,7 @@ If independent measurements converge to H₀ ≠ 70.4 km/s/Mpc at >3σ:
 - **H₀ = 73.0 ± 0.5 km/s/Mpc** (SH0ES confirmed) → **DESI CALIBRATION QUESTIONED**
 
 **Current Status:**
-⚠️ **UNCERTAIN** — JWST early results show 72.6 ± 2.0 km/s/Mpc (1.1σ from UIDT)
+⚠️ **UNCERTAIN** — The UIDT prediction of 70.4 km/s/Mpc is consistent with the latest CCHP measurements (2025). However, the underlying Hubble tension between Planck and SH0ES remains unresolved.
 
 **Timeline:**
 - **2025-2026:** JWST Cycle 3 Cepheid program

--- a/manuscript/UIDT_v3.9-Complete-Framework_correct_r0_deepseekT.tex
+++ b/manuscript/UIDT_v3.9-Complete-Framework_correct_r0_deepseekT.tex
@@ -1479,7 +1479,8 @@ compact simple gauge groups, not specific numerical value for SU(3).
 
 \begin{itemize}
     \item UIDT (calibrated context): $H_0 = 70.4 \pm 0.16\,\kms$ (Category C; DESI-calibrated)
-    \item CCHP TRGB (HST+JWST): $H_0 = 70.39 \pm 1.90\,\kms$
+    \item CCHP TRGB+JAGB (JWST-only): $H_0 = 69.0 \pm 1.75\,\kms$
+    \item CCHP (HST+JWST combined): $H_0 = 70.4 \pm 2.1\,\kms$ ($\pm 3\%$)
     \item Planck CMB (early-universe inference): $67.4 \pm 0.5\,\kms$
     \item SH0ES Cepheids (late-universe ladder): $73.2 \pm 0.9\,\kms$
 \end{itemize}


### PR DESCRIPTION
This PR executes Task 18 to purge fictitious cosmology artifacts related to H0 ("72.6 ± 2.0" and "70.39") and correctly updates the references to CCHP (2025) data, marking the prediction as Category C. Furthermore, the PR strictly enforces Stratum II compliance, clarifying that the underlying Hubble tension between Planck and SH0ES remains officially unresolved.

---
*PR created automatically by Jules for task [12236715134520227227](https://jules.google.com/task/12236715134520227227) started by @badbugsarts-hue*