### PR TITLE
[UIDT-v3.9] Monitoring: Add daily cosmology watch log for 2026-04-28

### DIFF
--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,8 @@
+[UIDT-v3.9] Monitoring: Add daily cosmology watch log for 2026-04-28
+Evidence category: [C]
+Limitation impact: none
+DOI: 10.5281/zenodo.17835200
+
+Added `monitoring/cosmology_watch_2026-04-28.md` tracking the latest DESI DR2 BAO measurements (arXiv:2503.14738) and w0 measurements (arXiv:2503.17659).
+Identified a 2.34σ tension in the H₀ value (68.53 vs UIDT 70.4) and issued a [TENSION ALERT].
+Confirmed w₀ (-1.01) is compatible within bounds (0.67σ from UIDT -0.99).

--- a/monitoring/cosmology_watch_2026-04-28.md
+++ b/monitoring/cosmology_watch_2026-04-28.md
@@ -1,0 +1,17 @@
+# Cosmology Watch Log 2026-04-28
+Operator: Jules (ALPHA-04)
+
+## DESI/Cosmology New Findings
+
+| Source | Parameter | Value | Uncertainty | UIDT Ledger | Tension σ | Alert |
+|--------|-----------|-------|-------------|-------------|-----------|-------|
+| DESI DR2 BAO (arXiv:2503.14738) | H₀ | 68.53 | ±0.80 | 70.4 | 2.34σ | YES |
+| DESI DR2 (arXiv:2503.17659) | w₀ | -1.01 | ±0.03 | -0.99 | 0.67σ | NO |
+
+## Status
+- H₀ tension: ONGOING (not resolved)
+- S₈ tension: ONGOING (not resolved)
+- w₀ UIDT alignment: compatible within bounds.
+
+## Action Required
+[TENSION ALERT issued for arXiv:2503.14738]


### PR DESCRIPTION
Added `monitoring/cosmology_watch_2026-04-28.md` tracking the latest DESI DR2 BAO measurements (arXiv:2503.14738) and w0 measurements (arXiv:2503.17659).
Identified a 2.34σ tension in the H₀ value (68.53 vs UIDT 70.4) and issued a [TENSION ALERT].
Confirmed w₀ (-1.01) is compatible within bounds (0.67σ from UIDT -0.99).

---
*PR created automatically by Jules for task [6897484650361699094](https://jules.google.com/task/6897484650361699094) started by @badbugsarts-hue*