### PR TITLE
[UIDT-v3.9] ci: add concurrency, timeout, shell safety to latex_build…

### DIFF
--- a/.github/workflows/latex_build_check.yml
+++ b/.github/workflows/latex_build_check.yml
@@ -10,22 +10,29 @@ on:
     paths:
       - 'manuscript/**/*.tex'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_latex:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Install TeX Live
+        shell: bash
         run: |
           sudo apt-get update
           sudo apt-get install -y texlive-latex-extra texlive-science texlive-bibtex-extra texlive-fonts-recommended
 
       - name: Compile CSF_UIDT_Unification.tex
         working-directory: manuscript
+        shell: bash
         run: |
           pdflatex -interaction=nonstopmode -halt-on-error CSF_UIDT_Unification.tex
           # Optionally run a second time for references
@@ -33,6 +40,7 @@ jobs:
 
       - name: Compile topological_quantization.tex
         working-directory: manuscript
+        shell: bash
         run: |
           pdflatex -interaction=nonstopmode -halt-on-error topological_quantization.tex
           pdflatex -interaction=nonstopmode -halt-on-error topological_quantization.tex


### PR DESCRIPTION
…_check.yml

Audit Protocol: Rule 17 / 18 / Pillar I Compliance
Severity: MEDIUM

### Evidence (Before/After)
- line:12 | # no concurrency block
+ line:12 | concurrency: { group: ..., cancel-in-progress: true }
- line:18 | steps: # no timeout-minutes
+ line:22 | timeout-minutes: 30
- line:23 | run: | # no shell: bash
+ line:28 | shell: bash (x3 run blocks)

Evidence category: N/A (CI infrastructure)
Limitation impact: none
DOI: 10.5281/zenodo.17835200

## UIDT v3.9 Pull Request

**Thank you for contributing!** This repository maintains strict scientific standards. Please complete this checklist before submitting your PR.

---

## ✅ Pre-Submission Checklist

### Commit Message Format
- [ ] Commit message follows format: `[UIDT] <type>: <summary>`
  - Types: `fix`, `docs`, `test`, `check`, `classify`, `placeholder`
  - Example: `[UIDT] docs: update falsification criteria for F2`
- [ ] Evidence category tag included: `[A]`, `[A-]`, `[B]`, `[C]`, `[D]`, or `[E]`
- [ ] Limitation impact documented if applicable: `L1`, `L2`, `L3`, `L4`, `L5`, `L6`, `L7`

### Code Changes
- [ ] **No changes to core constants:** Δ (1.710 GeV), γ (16.339), κ (0.500), λ_S (0.417)
  - Exception: Only if mathematical error in derivation is proven in PR description
- [ ] **mp.dps = 80** set in all modified modules (precision guard)
  - Never mocked, never centralised, always local
- [ ] **No deletions > 10 lines** in `core/` or `modules/` directories
- [ ] **Protected paths untouched:** `releases/`, `docs/`, `CANONICAL/` (read-only)

### Physics Claims
- [ ] **New physics claims** documented in PR description with:
  - Evidence category [A-E]
  - If Category A/B/C: cited data source
  - If Category D: prediction method
- [ ] **Cosmology claims** are Category C or below (never A or B)
- [ ] **γ parameter** never labelled as "derived" — always "calibrated [A-]"

### Verification
- [ ] Local verification passed:
  ```bash
  python verification/scripts/UIDT_Master_Verification.py
  pytest verification/ -v --tb=short
  ```
- [ ] Residuals remain < 10⁻¹⁴ for Category A claims
- [ ] No regression in numerical precision (80-digit arithmetic)

### Files Changed
**Summary of modified files:**
(List the files changed above in "Files changed" — approved types listed below)

| File Path | Change Type | Reason |
|---|---|---|
| | Code Optimization / Documentation / Test / Visualization | |

---

## 📋 Change Type Classification

**AUTO-APPROVED categories:**
- Typo fixes, formatting, comment clarifications
- Docstring improvements, type hints
- Documentation translations
- New visualization scripts

**REVIEW-REQUIRED categories:**
- Code optimization in `simulation/` or `scripts/`
- New tests in `verification/`
- New validation scripts

**ESCALATION-REQUIRED categories:**
- Any changes to `core/` directory
- Any changes to `modules/` directory
- Parameter changes (without proven derivation error)
- New physics claims

---

## 📝 Description

**What problem does this PR solve?**

**Implementation approach:**

**Testing method:**

---

## 🔗 Related Issues

Closes #

---

## ⚠️ Known Issues

(If any, list here — helps Claude's review)

---

**By submitting this PR, you agree:**
- Your contribution will be licensed under CC BY 4.0
- The UIDT-OS standards apply to all code changes
- Scientific integrity is maintained at all times
