### PR TITLE
[UIDT-v3.9] Monitoring: Add daily s102 status log

### DIFF
--- a/monitoring/s102_status_2026-05-03.md
+++ b/monitoring/s102_status_2026-05-03.md
@@ -1,0 +1,25 @@
+# S1-02 Monitor Log 2026-05-03
+Operator: Jules (ALPHA-06)
+
+## Current Status
+- N=99 occurrences: 90
+- N=94.05 occurrences: 34
+- New propagation since yesterday: NO
+
+## Active Locations N=99
+| File | Line | Context |
+|------|------|---------|
+| modules/covariant_unification.py | 27 | self.RG_STEPS = mpf('99') |
+| verification/scripts/verify_brst_dof_reduction.py | 4 | Target: Identify subtraction hypothesis leading to N=99 cascade steps. |
+
+## Impact Estimate
+- Relative difference: 5.26%
+- Affected observables: Vacuum energy density suppression ($\rho_{vac}$), Cosmological scaling factor mappings
+- Blocking resolution: Maintainer decision required on canonical N value (Option A: Confirm N=99 or Option B: Adopt N=94.05)
+
+## Escalation Required
+NO — Reason: No new propagation of the contradiction detected since baseline.
+
+## Decision Pending
+Awaiting maintainer decision on canonical N value.
+Jules will NOT change this value autonomously.


### PR DESCRIPTION
Creates daily monitor log for the S1-02 contradiction regarding N=99 vs N=94.05 as per the ALPHA-06 task. Validates no new propagation occurred since baseline.

---
*PR created automatically by Jules for task [14029207293985686048](https://jules.google.com/task/14029207293985686048) started by @badbugsarts-hue*