### PR TITLE
docs: Session-2 Phase-8 ledger sync corrections (TKT-2026-05-17)

### DIFF
--- a/CANONICAL/CONSTANTS.md
+++ b/CANONICAL/CONSTANTS.md
@@ -1,9 +1,9 @@
-# UIDT Canonical Constants v3.9.5
+# UIDT Canonical Constants v3.9.10
 
 > **STATUS:** Immutable until next version update  
 > **SOURCE:** Framework v3.6.1/v3.7.3/v3.9, DOI: 10.5281/zenodo.17835200  
-> **LAST VERIFIED:** 2026-04-03  
-> **AUDIT:** RG fixed-point precision correction (TKT-20260403-LAMBDA-FIX). PR #199 audit. Session 2026-04-03.
+> **LAST VERIFIED:** 2026-05-17  
+> **AUDIT:** RG fixed-point precision correction (TKT-20260403-LAMBDA-FIX) plus Session-2 Phase-8 intake sync (TKT-2026-05-17-session2-ledger-sync-phase8). No canonical evidence-category promotion.
 
 ---
 
@@ -55,6 +55,22 @@
 
 ---
 
+## Session-2 / Phase-8 Research Addendum
+
+> **Status:** Research addendum only. These quantities document Session-2 Phase-8 inputs and do **not** promote γ beyond [A-], do **not** alter Δ*, κ, λ_S, v, or E_T, and do **not** close L1/L4/L5.
+
+| Quantity | Symbol | Value | Category | Stratum | Notes |
+|----------|--------|-------|----------|---------|-------|
+| Bare-gamma conjecture | γ_bare | 49/3 = 16.333333333333333333333333333333333333333333333333333333333333333333333333333333 | D | III | Correct formula: γ_bare(Nc) = (2Nc+1)^2/Nc. The denominator is Nc, not Nc^2. |
+| Required correction | Δγ_required | 17/3000 = 0.0056666666666666666666666666666666666666666666666666666666666666666666666666666667 | D | III | γ − γ_bare using γ = 16.339 [A-]. Positive 1-loop/non-perturbative correction remains open. |
+| Tachyon threshold scale | k_crit | 4πE_T = 30.6619442990363820073953994208079481497643733379010328127154592209242881253534 MeV | D | III | Computed with E_T = 2.44 MeV [C]. The historical 30.707 MeV value implies E_T ≈ 2.443585 MeV and is not exact for E_T = 2.44 MeV. |
+| S4-P1 induced VEV | v_S4P1 | sqrt(12/5)·k_crit = 47.501279853002942537113076541729462153073066147889843469285377735931108003048118 MeV | D | III | Research-chain value; canonical v = 47.7 MeV [A] remains unchanged. |
+| Non-perturbative gamma shift | Δγ_NP | (Nc^2−1)/(4π^2)·v_S4P1/Δ* = 0.0056291063148914508559664078229635937676831402645376636439130762614790187510676005 | D | III | Uses Nc = 3, Δ* = 1.710 GeV [A], and v_S4P1 in MeV. |
+| S4-P1 gamma prediction | γ_pred | 16.338962439648224784189299741156296927101016473597870996977246409594812352084401 | D | III | Suggestive numerical chain only; |γ_pred − γ| = 0.000037560351775215810700258843703072898983526402129003022753590405187647915599066151. |
+| LPA' NLO Step-5 result | NO-GO-STEP5 | Z_phi(IR, λ3_phys) = 1.0000019 ≠ γ | D | III | LPA' NLO alone cannot derive γ from physical λ3(UV)=0.034823. Shooting λ3*≈99.638 is not physical. |
+
+---
+
 ## Constraint Equations
 
 ### Primary Constraint (v3.9.5 — exact)
@@ -84,6 +100,17 @@ $$\gamma_{\infty} = 16.3437 \quad \text{vs} \quad \gamma_{\text{kinetic}} = 16.3
 
 Deviation δγ ≈ 0.0047 (0.029%) — finite-size effect.
 
+### Session-2 Bare-Gamma Conjecture
+$$\gamma_{\mathrm{bare}}(N_c)=\frac{(2N_c+1)^2}{N_c},\qquad \gamma_{\mathrm{bare}}(3)=\frac{49}{3}.$$
+
+The expression $\frac{(2N_c+1)^2}{N_c^2}$ gives $49/9$ at $N_c=3$ and is therefore rejected for the Session-2 conjecture.
+
+### Session-2 Tachyon Threshold
+$$k_{\mathrm{crit}}=4\pi E_T.$$
+
+For $E_T=2.44\,\mathrm{MeV}$:
+$$k_{\mathrm{crit}}=30.6619442990363820073953994208079481497643733379010328127154592209242881253534\,\mathrm{MeV}.$$
+
 ---
 
 ## Evidence Category Rules (Quick Reference)
@@ -101,25 +128,29 @@ Non-existent: [A+], [B+], [C+], [D+]
 
 ---
 
-## Epistemic Audit Metadata (2026-03-30 / 2026-04-03)
+## Epistemic Audit Metadata (2026-03-30 / 2026-04-03 / 2026-05-17)
 
 | Parameter | external_crosscheck | upgrade_path | audit_date |
 |-----------|---------------------|--------------|------------|
 | γ = 16.339 | false | FRG scheme-independent observable reproducing γ without prior knowledge | 2026-03-30 |
 | E_T = 2.44 MeV | false | Dedicated lattice study with torsion operator in SU(3) vacuum targeting MeV regime | 2026-03-30 |
 | δγ = 0.0047 | false (numerical only) | Full NLO FRG truncation study (BMW/LPA') — TKT-20260403-FRG-NLO | 2026-04-03 |
+| γ_bare = 49/3 | false | Positive Δγ computation from first-principles 1-loop or non-perturbative FRG path | 2026-05-17 |
+| γ_pred = 16.338962439648... | false | Regulator-independent Wetterich-flow derivation plus external validation | 2026-05-17 |
 
-> Source: Issue #192, PR #193, PR #199. Stratum III classification for all three. Values immutable.
+> Source: Issue #192, PR #193, PR #199, PR #357, PR #362, PR #367, PR #369, PR #358. Stratum III classification for Session-2 quantities. Values are research addenda, not canonical promotions.
 
 ---
 
-## Open Issues (from Audit 2026-02-28 / 2026-03-30 / 2026-04-03)
+## Open Issues (from Audit 2026-02-28 / 2026-03-30 / 2026-04-03 / 2026-05-17)
 
 - **S1-01:** w_a L-dependence — holographic length L not canonical
 - **S1-02:** N=99 vs N=94.05 contradiction in code vs docs
 - **S1-04:** ~~w₀ triple inconsistency~~ → **RESOLVED** 2026-03-02. Canonical w₀ = −0.99 per Decision D-002.
 - **L1:** 10¹⁰ geometric factor UNEXPLAINED
+- **L1-S2:** γ_bare = 49/3 remains a conjecture. Required Δγ = +17/3000 has not been derived.
 - **L4:** γ NOT derived from RG first principles — algebraic closed-form yields γ ≈ 1.908, not 16.33 (PR #199, §1.4)
+- **L4-S5:** [NO-GO-STEP5] LPA' NLO with physical λ3 does not generate γ.
 - **L5:** N=99 steps unjustified
 - **TKT-20260403-FRG-NLO:** Full NLO FRG truncation study required before δγ = δ_NLO assessment
 - **TKT-20260403-TOPO-CLAIMS:** UIDT-C-TOPO-01/02/03 registration in CLAIMS.json pending (PR #190 OT-3)
@@ -130,6 +161,7 @@ Non-existent: [A+], [B+], [C+], [D+]
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| v3.9.10 | 2026-05-17 | Session-2 Phase-8 research addendum: γ_bare formula correction, k_crit recalculation for E_T=2.44 MeV, γ_pred chain documented as [D] Stratum III only. No evidence-category promotion. |
 | v3.9.5 | 2026-04-03 | λ_S → exact 5κ²/3 (TKT-20260403-LAMBDA-FIX). RG constraint < 10⁻¹⁴. Epistemic audit metadata added. |
 | v3.9.4 | 2026-03-02 | w₀ = −0.99 canonical (D-002). S1-04 resolved. Session #16 audit. |
 | v3.9.3 | 2026-02-28 | Added δγ, C-068/C-069. PR Review #100-#115. 55 claims. |
@@ -160,6 +192,13 @@ w₀ = -0.99               [C]  Dark energy EOS (Decision D-002)
 w_a = L-dependent         [C]  Holographic DE evolution
 Σmν ≤ 0.16 eV            [D]  Neutrino mass sum
 δγ = 0.0047              [B]  Vacuum dressing shift (FSS)
+
+Session-2 / Phase-8 research addendum, not canonical promotion:
+γ_bare = 49/3            [D]  Conjecture: (2Nc+1)^2/Nc at Nc=3
+Δγ_required = 17/3000    [D]  Required positive correction to γ=16.339
+k_crit = 4πE_T = 30.661944299036382... MeV [D] for E_T=2.44 MeV
+γ_pred = 16.338962439648224... [D] S4-P1 numerical chain
+NO-GO-STEP5              [D]  LPA' NLO with physical λ3 does not derive γ
 ```
 
 ---

--- a/LEDGER/SESSION2_PHASE8_CLAIMS_SYNC.md
+++ b/LEDGER/SESSION2_PHASE8_CLAIMS_SYNC.md
@@ -4,7 +4,8 @@
 > **Branch:** `TKT-2026-05-17-session2-ledger-sync-phase8`  
 > **Date:** 2026-05-17  
 > **DOI:** `10.5281/zenodo.17835200`  
-> **Status:** Ledger-sync staging document. This file does **not** promote evidence categories and does **not** close L1/L4/L5.
+> **Status:** Ledger-sync staging document. This file does **not** promote evidence categories and does **not** close L1/L4/L5.  
+> **Guardian status:** `GUARDIAN_REVIEW_REQUIRED` because this document stages claims under `LEDGER/`; no direct `CLAIMS.json` mutation is performed.
 
 ---
 
@@ -18,6 +19,20 @@ The changes are append-only at the claim level:
 2. Recompute `k_crit = 4πE_T` using the canonical `E_T = 2.44 MeV`.
 3. Register the S4-P1 gamma-chain as [D] / Stratum III only.
 4. Register `[NO-GO-STEP5]` as a documented limitation of the LPA' NLO path.
+
+---
+
+## Guardian / SSOT Gate
+
+This file is intentionally a staging document rather than a direct edit of `LEDGER/CLAIMS.json`.
+
+| Gate | Status | Rationale |
+|---|---|---|
+| Reviewer | Required | The staged claims touch the evidence ledger surface. |
+| Regressor | Required | `python verification/scripts/verify_session2_phase8_sync.py` must pass before any claim migration. |
+| Auditor | Required | Evidence tags must remain [D] / Stratum III; no [A], [B], or [C] promotion is requested. |
+
+**Merge condition:** Before any migration into `LEDGER/CLAIMS.json`, the Guardian chain must explicitly return PASS for Reviewer, Regressor, and Auditor. A single failure blocks migration.
 
 ---
 
@@ -186,12 +201,12 @@ python verification/scripts/verify_session2_phase8_sync.py
 Expected result:
 
 ```text
-[PASS] gamma_bare formula corrected: 49/3
-[PASS] rejected wrong denominator: 49/9
-[PASS] Delta_gamma_required = 17/3000
-[PASS] k_crit = 4*pi*E_T for E_T=2.44 MeV
-[PASS] gamma_pred chain = 16.338962439648224...
-[PASS] RG constraint residual = 0
+[PASS] gamma_bare formula corrected residual: < 1e-70
+[PASS] wrong denominator rejected as 49/9 residual: < 1e-70
+[PASS] Delta_gamma_required = 17/3000 residual: < 1e-70
+[PASS] k_crit = 4*pi*E_T for E_T=2.44 MeV residual: < 1e-70
+[PASS] gamma_pred chain residual: < 1e-70
+[PASS] RG constraint residual: 0.0
 ALL SESSION-2 PHASE-8 SYNC CHECKS PASSED
 ```
 

--- a/LEDGER/SESSION2_PHASE8_CLAIMS_SYNC.md
+++ b/LEDGER/SESSION2_PHASE8_CLAIMS_SYNC.md
@@ -1,0 +1,220 @@
+# Session-2 Phase-8 Claims Sync
+
+> **UIDT Framework:** v3.9 Canonical  
+> **Branch:** `TKT-2026-05-17-session2-ledger-sync-phase8`  
+> **Date:** 2026-05-17  
+> **DOI:** `10.5281/zenodo.17835200`  
+> **Status:** Ledger-sync staging document. This file does **not** promote evidence categories and does **not** close L1/L4/L5.
+
+---
+
+## Purpose
+
+This document stages the Session-2 / Phase-8 claims that must be reviewed before integration into `LEDGER/CLAIMS.json`. It exists because `LEDGER/CLAIMS.json` has a recent recovery history and should not be blindly rewritten without explicit review.
+
+The changes are append-only at the claim level:
+
+1. Correct the Session-2 bare-gamma formula.
+2. Recompute `k_crit = 4πE_T` using the canonical `E_T = 2.44 MeV`.
+3. Register the S4-P1 gamma-chain as [D] / Stratum III only.
+4. Register `[NO-GO-STEP5]` as a documented limitation of the LPA' NLO path.
+
+---
+
+## Critical Corrections
+
+### C1 — Bare-gamma denominator correction
+
+Incorrect handover expression:
+
+```text
+γ_bare = (2Nc+1)^2 / Nc^2
+```
+
+For `Nc = 3`, this gives `49/9 = 5.444...`, not `49/3`.
+
+Correct Session-2 expression:
+
+```text
+γ_bare(Nc) = (2Nc+1)^2 / Nc
+γ_bare(3) = 49/3 = 16.333333333333...
+```
+
+Evidence status: **[D] Stratum III**. This is a conjectural algebraic identification, not an [A] derivation.
+
+### C2 — Tachyon threshold numerical correction
+
+With canonical `E_T = 2.44 MeV [C]`:
+
+```text
+k_crit = 4πE_T
+       = 30.6619442990363820073953994208079481497643733379010328127154592209242881253534 MeV
+```
+
+The historical value `30.707 MeV` implies:
+
+```text
+E_T = 30.707 / (4π) = 2.4435854187... MeV
+```
+
+Therefore `30.707 MeV` must not be recorded as exact for `E_T = 2.44 MeV`.
+
+---
+
+## Claims Table
+
+| Claim ID | Claim | Value | Evidence Tag | Stratum | Source | Status | Falsification Exposure |
+|---|---:|---:|---|---|---|---|---|
+| UIDT-S2-001 | Bare-gamma conjecture | γ_bare(Nc)=((2Nc+1)^2)/Nc; γ_bare(3)=49/3 | [D] | III | PR #367 / Phase-8 intake | Staged | Reject if Δγ correction is negative, >0.012, or SU(4) scaling fails. |
+| UIDT-S2-002 | Required positive correction | Δγ_required=17/3000=0.005666666666... | [D] | III | PR #367 / verification script | Staged | Reject L1 ansatz if first-principles Δγ is negative or outside acceptance band. |
+| UIDT-S4P1-001 | Tachyon threshold with canonical E_T | k_crit=4πE_T=30.6619442990... MeV | [D] | III | PR #369 / corrected numerical audit | Staged | Fails if regulator-independent Wetterich trace does not reproduce onset within E_T uncertainty. |
+| UIDT-S4P1-002 | S4-P1 induced VEV | v_S4P1=sqrt(12/5)·k_crit=47.5012798530... MeV | [D] | III | PR #369 / corrected numerical audit | Staged | Fails if the full flow cannot recover canonical v=47.7 MeV within uncertainty. |
+| UIDT-S4P1-003 | Non-perturbative gamma shift | Δγ_NP=0.00562910631489145... | [D] | III | PR #369 / corrected numerical audit | Staged | Fails if full Wetterich flow gives incompatible Δγ_NP. |
+| UIDT-S4P1-004 | S4-P1 gamma prediction | γ_pred=16.338962439648224... | [D] | III | PR #369 / corrected numerical audit | Staged | Fails if regulator-independence or full flow shifts γ_pred outside the calibration band. |
+| UIDT-S5-001 | `[NO-GO-STEP5]` LPA' NLO physical path | Z_phi(IR, λ3_phys)=1.0000019 ≠ γ | [D] | III | PR #362 | Staged | Overturned only by independently reproduced LPA'+Y/BMW derivation from physical λ3. |
+
+---
+
+## Proposed CLAIMS.json Append Entries
+
+```json
+[
+  {
+    "id": "UIDT-S2-001",
+    "statement": "Bare gamma conjecture gamma_bare(Nc) = (2Nc+1)^2/Nc, giving gamma_bare(3) = 49/3 = 16.333333333333...",
+    "type": "hypothesis",
+    "status": "conjectured",
+    "evidence": "D",
+    "confidence": 0.55,
+    "dependencies": ["UIDT-C-002", "UIDT-C-052", "PR-367"],
+    "since": "v3.9-session2-phase8",
+    "stratum": "III",
+    "notes": "Correct Session-2 denominator is Nc, not Nc^2. The Nc^2 denominator yields 49/9 for SU(3) and is rejected. This does not upgrade gamma beyond [A-].",
+    "falsification": "If the required Delta_gamma correction is negative, exceeds 0.012, or SU(4) scaling fails the (2Nc+1)^2/Nc structure."
+  },
+  {
+    "id": "UIDT-S2-002",
+    "statement": "Required correction Delta_gamma_required = gamma_ledger - gamma_bare = 17/3000 = 0.005666666666...",
+    "type": "derivation",
+    "status": "open",
+    "evidence": "D",
+    "confidence": 0.5,
+    "dependencies": ["UIDT-S2-001", "UIDT-C-002", "PR-367"],
+    "since": "v3.9-session2-phase8",
+    "stratum": "III",
+    "notes": "Positive correction required to connect gamma_bare=49/3 to gamma=16.339 [A-]. No first-principles 1-loop computation exists yet.",
+    "falsification": "If a first-principles 1-loop or FRG correction gives Delta_gamma < 0 or Delta_gamma > 0.012, the L1 bare-gamma ansatz is rejected."
+  },
+  {
+    "id": "UIDT-S4P1-001",
+    "statement": "S4-P1 critical scale k_crit = 4*pi*E_T = 30.6619442990... MeV for E_T = 2.44 MeV.",
+    "type": "derivation",
+    "status": "conjectured",
+    "evidence": "D",
+    "confidence": 0.55,
+    "dependencies": ["UIDT-C-044", "PR-369"],
+    "since": "v3.9-session2-phase8",
+    "stratum": "III",
+    "notes": "Numerical tachyon-threshold chain. The historical 30.707 MeV value implies E_T≈2.443585 MeV and must not be presented as exact for E_T=2.44 MeV.",
+    "falsification": "If regulator-independence checks fail or the full Wetterich trace does not reproduce the onset within the E_T uncertainty band."
+  },
+  {
+    "id": "UIDT-S4P1-002",
+    "statement": "S4-P1 induced VEV v_S4P1 = sqrt(12/5)*k_crit = 47.5012798530... MeV using E_T=2.44 MeV.",
+    "type": "derivation",
+    "status": "conjectured",
+    "evidence": "D",
+    "confidence": 0.55,
+    "dependencies": ["UIDT-S4P1-001", "UIDT-C-004", "PR-369"],
+    "since": "v3.9-session2-phase8",
+    "stratum": "III",
+    "notes": "Research-chain value only. Canonical v=47.7 MeV [A] remains unchanged.",
+    "falsification": "If the full flow cannot recover canonical v=47.7 MeV within uncertainty without free-parameter insertion."
+  },
+  {
+    "id": "UIDT-S4P1-003",
+    "statement": "S4-P1 non-perturbative gamma shift Delta_gamma_NP = (Nc^2-1)/(4*pi^2)*v_S4P1/Delta* = 0.00562910631489145...",
+    "type": "prediction",
+    "status": "predicted",
+    "evidence": "D",
+    "confidence": 0.55,
+    "dependencies": ["UIDT-S4P1-002", "UIDT-C-001", "PR-369"],
+    "since": "v3.9-session2-phase8",
+    "stratum": "III",
+    "notes": "Uses Nc=3, Delta*=1.710 GeV, and v_S4P1 in MeV. This is not an algebraic proof.",
+    "falsification": "If full Wetterich flow gives incompatible Delta_gamma_NP."
+  },
+  {
+    "id": "UIDT-S4P1-004",
+    "statement": "S4-P1 gamma prediction gamma_pred = 16.338962439648224... from gamma_bare + Delta_gamma_NP.",
+    "type": "prediction",
+    "status": "predicted",
+    "evidence": "D",
+    "confidence": 0.55,
+    "dependencies": ["UIDT-S2-001", "UIDT-S4P1-003", "UIDT-C-002", "PR-369"],
+    "since": "v3.9-session2-phase8",
+    "stratum": "III",
+    "notes": "Suggestive numerical proximity to gamma=16.339 [A-]. Does not upgrade gamma beyond [A-].",
+    "falsification": "If full Wetterich flow or regulator-independence checks shift gamma_pred outside the gamma calibration band."
+  },
+  {
+    "id": "UIDT-S5-001",
+    "statement": "[NO-GO-STEP5]: LPA' NLO with physical lambda3(UV)=0.034823 yields Z_phi(IR)=1.0000019, not gamma=16.339.",
+    "type": "no-go",
+    "status": "verified",
+    "evidence": "D",
+    "confidence": 0.8,
+    "dependencies": ["PR-362", "verification/scripts/research/verify_frg_step5_lambda3_flow.py"],
+    "since": "v3.9-session2-phase8",
+    "stratum": "III",
+    "notes": "LPA' NLO alone cannot derive gamma. Shooting solution requires lambda3*=99.638, about 2857 times physical lambda3.",
+    "falsification": "If an independently reproduced LPA'+Y or BMW truncation derives gamma from physical lambda3 without violating 5kappa^2=3lambda_S."
+  }
+]
+```
+
+---
+
+## Reproduction Note
+
+Single command:
+
+```bash
+python verification/scripts/verify_session2_phase8_sync.py
+```
+
+Expected result:
+
+```text
+[PASS] gamma_bare formula corrected: 49/3
+[PASS] rejected wrong denominator: 49/9
+[PASS] Delta_gamma_required = 17/3000
+[PASS] k_crit = 4*pi*E_T for E_T=2.44 MeV
+[PASS] gamma_pred chain = 16.338962439648224...
+[PASS] RG constraint residual = 0
+ALL SESSION-2 PHASE-8 SYNC CHECKS PASSED
+```
+
+---
+
+## Verified References
+
+| DOI/arXiv/PR | Status | Used for | Evidence Tag |
+|---|---|---|---|
+| DOI `10.5281/zenodo.17835200` | Project DOI | UIDT canonical project identity | n/a |
+| PR #367 | Repository-internal merged PR | γ_bare Session-2 derivation context | [D] |
+| PR #369 | Repository-internal merged PR | S4-P1 tachyon-threshold chain | [D] |
+| PR #362 | Repository-internal merged PR | `[NO-GO-STEP5]` | [D] |
+| PR #358 | Repository-internal merged PR | L1/L4/L5 formal no-go context | [D/E context] |
+
+No new external DOI/arXiv source is required for these staged claims. No claim is promoted to [B] or [C].
+
+---
+
+## Limitations
+
+- L1 remains open: γ_bare is not an [A] derivation.
+- L4 remains open: S4-P1 is a numerical chain, not a regulator-independent Wetterich proof.
+- L5 remains open: N=99 is not derived in this sync.
+- The value γ=16.339 remains [A-].
+- The historical value `k_crit≈30.707 MeV` is not exact for `E_T=2.44 MeV`.

--- a/verification/scripts/verify_session2_phase8_sync.py
+++ b/verification/scripts/verify_session2_phase8_sync.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+UIDT v3.9 — Session-2 Phase-8 ledger-sync verification.
+
+Purpose
+-------
+Verify the arithmetic used by the Session-2 / Phase-8 constants and
+ledger staging addendum. This script is intentionally narrow: it checks
+only the corrected formula, the canonical E_T threshold value, the
+S4-P1 numerical chain, and the exact RG constraint.
+
+Evidence policy
+---------------
+- gamma = 16.339 remains [A-].
+- gamma_bare = 49/3 remains [D] Stratum III.
+- gamma_pred remains [D] Stratum III.
+- No evidence-category promotion is performed by this script.
+
+Reproduction
+------------
+python verification/scripts/verify_session2_phase8_sync.py
+"""
+
+from __future__ import annotations
+
+import mpmath as mp
+
+
+def main() -> None:
+    mp.dps = 80
+
+    nc = mp.mpf(3)
+    gamma_ledger = mp.mpf("16.339")
+    delta_star_mev = mp.mpf("1710")
+    e_t_mev = mp.mpf("2.44")
+    kappa = mp.mpf(1) / mp.mpf(2)
+    lambda_s = mp.mpf(5) / mp.mpf(12)
+
+    gamma_bare = (2 * nc + 1) ** 2 / nc
+    gamma_wrong_denominator = (2 * nc + 1) ** 2 / (nc**2)
+    delta_gamma_required = gamma_ledger - gamma_bare
+
+    k_crit_mev = 4 * mp.pi * e_t_mev
+    v_s4p1_mev = mp.sqrt(mp.mpf(12) / mp.mpf(5)) * k_crit_mev
+    delta_gamma_np = (nc**2 - 1) / (4 * mp.pi**2) * (v_s4p1_mev / delta_star_mev)
+    gamma_pred = gamma_bare + delta_gamma_np
+    gamma_pred_residual = abs(gamma_pred - gamma_ledger)
+
+    rg_residual = abs(5 * kappa**2 - 3 * lambda_s)
+
+    assert gamma_bare == mp.mpf(49) / mp.mpf(3), mp.nstr(gamma_bare, 80)
+    print("[PASS] gamma_bare formula corrected:", mp.nstr(gamma_bare, 80))
+
+    assert gamma_wrong_denominator == mp.mpf(49) / mp.mpf(9), mp.nstr(
+        gamma_wrong_denominator, 80
+    )
+    assert gamma_wrong_denominator != gamma_bare
+    print("[PASS] rejected wrong denominator:", mp.nstr(gamma_wrong_denominator, 80))
+
+    assert delta_gamma_required == mp.mpf(17) / mp.mpf(3000), mp.nstr(
+        delta_gamma_required, 80
+    )
+    assert delta_gamma_required > 0
+    print("[PASS] Delta_gamma_required:", mp.nstr(delta_gamma_required, 80))
+
+    expected_kcrit = mp.mpf(
+        "30.6619442990363820073953994208079481497643733379010328127154592209242881253534"
+    )
+    assert abs(k_crit_mev - expected_kcrit) < mp.mpf("1e-78"), mp.nstr(
+        abs(k_crit_mev - expected_kcrit), 80
+    )
+    print("[PASS] k_crit = 4*pi*E_T:", mp.nstr(k_crit_mev, 80), "MeV")
+
+    expected_gamma_pred = mp.mpf(
+        "16.338962439648224784189299741156296927101016473597870996977246409594812352084401"
+    )
+    assert abs(gamma_pred - expected_gamma_pred) < mp.mpf("1e-78"), mp.nstr(
+        abs(gamma_pred - expected_gamma_pred), 80
+    )
+    print("[PASS] gamma_pred chain:", mp.nstr(gamma_pred, 80))
+    print("[INFO] |gamma_pred - gamma_ledger|:", mp.nstr(gamma_pred_residual, 80))
+
+    assert rg_residual == 0
+    print("[PASS] RG constraint residual:", mp.nstr(rg_residual, 80))
+
+    print("ALL SESSION-2 PHASE-8 SYNC CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/verification/scripts/verify_session2_phase8_sync.py
+++ b/verification/scripts/verify_session2_phase8_sync.py
@@ -1,50 +1,15 @@
 #!/usr/bin/env python3
-"""
-UIDT v3.9 — Session-2 Phase-8 ledger-sync verification.
-
-Purpose
--------
-Verify the arithmetic used by the Session-2 / Phase-8 constants and
-ledger staging addendum. This script is intentionally narrow: it checks
-only the corrected formula, the canonical E_T threshold value, the
-S4-P1 numerical chain, and the exact RG constraint.
-
-Evidence policy
----------------
-- gamma = 16.339 remains [A-].
-- gamma_bare = 49/3 remains [D] Stratum III.
-- gamma_pred remains [D] Stratum III.
-- No evidence-category promotion is performed by this script.
-
-Numerical policy
-----------------
-All comparisons involving decimal ledger inputs and rational reconstructions
-use explicit residual checks. Exact mp.mpf equality is reserved only for
-constructs that are expected to close exactly through the same construction
-path. This avoids brittle decimal/rational equality failures while preserving
-UIDT's <1e-14 residual discipline.
-
-Reproduction
-------------
-python verification/scripts/verify_session2_phase8_sync.py
-"""
+"""UIDT v3.9 Session-2 Phase-8 arithmetic verification."""
 
 from __future__ import annotations
 
-import mpmath as mp
+from mpmath import mp
 
 
-def _assert_residual(
-    label: str,
-    value: mp.mpf,
-    expected: mp.mpf,
-    tolerance: mp.mpf,
-) -> mp.mpf:
-    """Fail fast unless |value - expected| is below tolerance."""
+def assert_residual(label: str, value: mp.mpf, expected: mp.mpf, tol: mp.mpf) -> mp.mpf:
     residual = abs(value - expected)
-    assert residual < tolerance, (
-        f"{label} residual {mp.nstr(residual, 80)} exceeds "
-        f"tolerance {mp.nstr(tolerance, 20)}"
+    assert residual < tol, (
+        f"{label} residual {mp.nstr(residual, 80)} exceeds {mp.nstr(tol, 20)}"
     )
     print(f"[PASS] {label} residual:", mp.nstr(residual, 80))
     return residual
@@ -52,9 +17,8 @@ def _assert_residual(
 
 def main() -> None:
     mp.dps = 80
-
-    tight_tolerance = mp.mpf("1e-70")
-    proof_tolerance = mp.mpf("1e-14")
+    tight_tol = mp.mpf("1e-70")
+    proof_tol = mp.mpf("1e-14")
 
     nc = mp.mpf(3)
     gamma_ledger = mp.mpf("16.339")
@@ -64,70 +28,46 @@ def main() -> None:
     lambda_s = mp.mpf(5) / mp.mpf(12)
 
     gamma_bare = (2 * nc + 1) ** 2 / nc
-    gamma_wrong_denominator = (2 * nc + 1) ** 2 / (nc**2)
+    gamma_wrong = (2 * nc + 1) ** 2 / (nc**2)
     delta_gamma_required = gamma_ledger - gamma_bare
-
     k_crit_mev = 4 * mp.pi * e_t_mev
     v_s4p1_mev = mp.sqrt(mp.mpf(12) / mp.mpf(5)) * k_crit_mev
     delta_gamma_np = (nc**2 - 1) / (4 * mp.pi**2) * (v_s4p1_mev / delta_star_mev)
     gamma_pred = gamma_bare + delta_gamma_np
     gamma_pred_residual = abs(gamma_pred - gamma_ledger)
-
     rg_residual = abs(5 * kappa**2 - 3 * lambda_s)
 
-    _assert_residual(
-        "gamma_bare formula corrected",
-        gamma_bare,
-        mp.mpf(49) / mp.mpf(3),
-        tight_tolerance,
-    )
-    print("[INFO] gamma_bare:", mp.nstr(gamma_bare, 80))
-
-    _assert_residual(
-        "wrong denominator rejected as 49/9",
-        gamma_wrong_denominator,
-        mp.mpf(49) / mp.mpf(9),
-        tight_tolerance,
-    )
-    assert gamma_wrong_denominator != gamma_bare
-    print("[INFO] rejected wrong denominator:", mp.nstr(gamma_wrong_denominator, 80))
-
-    expected_delta_gamma_required = mp.mpf(17) / mp.mpf(3000)
-    _assert_residual(
+    assert_residual("gamma_bare = 49/3", gamma_bare, mp.mpf(49) / mp.mpf(3), tight_tol)
+    assert_residual("wrong denominator = 49/9", gamma_wrong, mp.mpf(49) / mp.mpf(9), tight_tol)
+    assert gamma_wrong != gamma_bare
+    assert_residual(
         "Delta_gamma_required = 17/3000",
         delta_gamma_required,
-        expected_delta_gamma_required,
-        tight_tolerance,
+        mp.mpf(17) / mp.mpf(3000),
+        tight_tol,
     )
     assert delta_gamma_required > 0
-    print("[INFO] Delta_gamma_required:", mp.nstr(delta_gamma_required, 80))
 
-    expected_kcrit = mp.mpf(
-        "30.6619442990363820073953994208079481497643733379010328127154592209242881253534"
-    )
-    _assert_residual(
-        "k_crit = 4*pi*E_T for E_T=2.44 MeV",
+    assert_residual(
+        "k_crit = 4*pi*E_T",
         k_crit_mev,
-        expected_kcrit,
-        tight_tolerance,
+        mp.mpf("30.6619442990363820073953994208079481497643733379010328127154592209242881253534"),
+        tight_tol,
     )
-    print("[INFO] k_crit:", mp.nstr(k_crit_mev, 80), "MeV")
-
-    expected_gamma_pred = mp.mpf(
-        "16.338962439648224784189299741156296927101016473597870996977246409594812352084401"
-    )
-    _assert_residual(
+    assert_residual(
         "gamma_pred chain",
         gamma_pred,
-        expected_gamma_pred,
-        tight_tolerance,
+        mp.mpf("16.338962439648224784189299741156296927101016473597870996977246409594812352084401"),
+        tight_tol,
     )
+    assert rg_residual < proof_tol, mp.nstr(rg_residual, 80)
+
+    print("[INFO] gamma_bare:", mp.nstr(gamma_bare, 80))
+    print("[INFO] Delta_gamma_required:", mp.nstr(delta_gamma_required, 80))
+    print("[INFO] k_crit_mev:", mp.nstr(k_crit_mev, 80))
     print("[INFO] gamma_pred:", mp.nstr(gamma_pred, 80))
     print("[INFO] |gamma_pred - gamma_ledger|:", mp.nstr(gamma_pred_residual, 80))
-
-    assert rg_residual < proof_tolerance, mp.nstr(rg_residual, 80)
     print("[PASS] RG constraint residual:", mp.nstr(rg_residual, 80))
-
     print("ALL SESSION-2 PHASE-8 SYNC CHECKS PASSED")
 
 

--- a/verification/scripts/verify_session2_phase8_sync.py
+++ b/verification/scripts/verify_session2_phase8_sync.py
@@ -16,6 +16,14 @@ Evidence policy
 - gamma_pred remains [D] Stratum III.
 - No evidence-category promotion is performed by this script.
 
+Numerical policy
+----------------
+All comparisons involving decimal ledger inputs and rational reconstructions
+use explicit residual checks. Exact mp.mpf equality is reserved only for
+constructs that are expected to close exactly through the same construction
+path. This avoids brittle decimal/rational equality failures while preserving
+UIDT's <1e-14 residual discipline.
+
 Reproduction
 ------------
 python verification/scripts/verify_session2_phase8_sync.py
@@ -26,8 +34,27 @@ from __future__ import annotations
 import mpmath as mp
 
 
+def _assert_residual(
+    label: str,
+    value: mp.mpf,
+    expected: mp.mpf,
+    tolerance: mp.mpf,
+) -> mp.mpf:
+    """Fail fast unless |value - expected| is below tolerance."""
+    residual = abs(value - expected)
+    assert residual < tolerance, (
+        f"{label} residual {mp.nstr(residual, 80)} exceeds "
+        f"tolerance {mp.nstr(tolerance, 20)}"
+    )
+    print(f"[PASS] {label} residual:", mp.nstr(residual, 80))
+    return residual
+
+
 def main() -> None:
     mp.dps = 80
+
+    tight_tolerance = mp.mpf("1e-70")
+    proof_tolerance = mp.mpf("1e-14")
 
     nc = mp.mpf(3)
     gamma_ledger = mp.mpf("16.339")
@@ -48,39 +75,57 @@ def main() -> None:
 
     rg_residual = abs(5 * kappa**2 - 3 * lambda_s)
 
-    assert gamma_bare == mp.mpf(49) / mp.mpf(3), mp.nstr(gamma_bare, 80)
-    print("[PASS] gamma_bare formula corrected:", mp.nstr(gamma_bare, 80))
+    _assert_residual(
+        "gamma_bare formula corrected",
+        gamma_bare,
+        mp.mpf(49) / mp.mpf(3),
+        tight_tolerance,
+    )
+    print("[INFO] gamma_bare:", mp.nstr(gamma_bare, 80))
 
-    assert gamma_wrong_denominator == mp.mpf(49) / mp.mpf(9), mp.nstr(
-        gamma_wrong_denominator, 80
+    _assert_residual(
+        "wrong denominator rejected as 49/9",
+        gamma_wrong_denominator,
+        mp.mpf(49) / mp.mpf(9),
+        tight_tolerance,
     )
     assert gamma_wrong_denominator != gamma_bare
-    print("[PASS] rejected wrong denominator:", mp.nstr(gamma_wrong_denominator, 80))
+    print("[INFO] rejected wrong denominator:", mp.nstr(gamma_wrong_denominator, 80))
 
-    assert delta_gamma_required == mp.mpf(17) / mp.mpf(3000), mp.nstr(
-        delta_gamma_required, 80
+    expected_delta_gamma_required = mp.mpf(17) / mp.mpf(3000)
+    _assert_residual(
+        "Delta_gamma_required = 17/3000",
+        delta_gamma_required,
+        expected_delta_gamma_required,
+        tight_tolerance,
     )
     assert delta_gamma_required > 0
-    print("[PASS] Delta_gamma_required:", mp.nstr(delta_gamma_required, 80))
+    print("[INFO] Delta_gamma_required:", mp.nstr(delta_gamma_required, 80))
 
     expected_kcrit = mp.mpf(
         "30.6619442990363820073953994208079481497643733379010328127154592209242881253534"
     )
-    assert abs(k_crit_mev - expected_kcrit) < mp.mpf("1e-78"), mp.nstr(
-        abs(k_crit_mev - expected_kcrit), 80
+    _assert_residual(
+        "k_crit = 4*pi*E_T for E_T=2.44 MeV",
+        k_crit_mev,
+        expected_kcrit,
+        tight_tolerance,
     )
-    print("[PASS] k_crit = 4*pi*E_T:", mp.nstr(k_crit_mev, 80), "MeV")
+    print("[INFO] k_crit:", mp.nstr(k_crit_mev, 80), "MeV")
 
     expected_gamma_pred = mp.mpf(
         "16.338962439648224784189299741156296927101016473597870996977246409594812352084401"
     )
-    assert abs(gamma_pred - expected_gamma_pred) < mp.mpf("1e-78"), mp.nstr(
-        abs(gamma_pred - expected_gamma_pred), 80
+    _assert_residual(
+        "gamma_pred chain",
+        gamma_pred,
+        expected_gamma_pred,
+        tight_tolerance,
     )
-    print("[PASS] gamma_pred chain:", mp.nstr(gamma_pred, 80))
+    print("[INFO] gamma_pred:", mp.nstr(gamma_pred, 80))
     print("[INFO] |gamma_pred - gamma_ledger|:", mp.nstr(gamma_pred_residual, 80))
 
-    assert rg_residual == 0
+    assert rg_residual < proof_tolerance, mp.nstr(rg_residual, 80)
     print("[PASS] RG constraint residual:", mp.nstr(rg_residual, 80))
 
     print("ALL SESSION-2 PHASE-8 SYNC CHECKS PASSED")

--- a/verification/scripts/verify_session2_phase8_sync.py
+++ b/verification/scripts/verify_session2_phase8_sync.py
@@ -7,6 +7,7 @@ from mpmath import mp
 
 
 def assert_residual(label: str, value: mp.mpf, expected: mp.mpf, tol: mp.mpf) -> mp.mpf:
+    mp.dps = 80
     residual = abs(value - expected)
     assert residual < tol, (
         f"{label} residual {mp.nstr(residual, 80)} exceeds {mp.nstr(tol, 20)}"


### PR DESCRIPTION
## Summary

This Draft PR stages the Session-2 / Phase-8 ledger synchronization before the L1/L4/L5 deep-dive plan is continued.

It corrects two blocking numerical issues in the handover:

1. `gamma_bare(Nc)` denominator correction:
   - rejected: `(2Nc+1)^2/Nc^2` because SU(3) gives `49/9`, not `49/3`
   - accepted for Session-2 staging: `(2Nc+1)^2/Nc`, giving `49/3`
2. `k_crit = 4*pi*E_T` recalculation for canonical `E_T = 2.44 MeV`:
   - `k_crit = 30.661944299036382... MeV`
   - the historical `30.707 MeV` value implies `E_T ≈ 2.443585 MeV` and is not exact for `E_T = 2.44 MeV`

No evidence-category promotion is made. `gamma = 16.339` remains `[A-]`.

---

## Files changed

| File | Purpose |
|---|---|
| `CANONICAL/CONSTANTS.md` | Adds Session-2 / Phase-8 research addendum and corrected numerical values. |
| `LEDGER/SESSION2_PHASE8_CLAIMS_SYNC.md` | Stages append-only claims for later controlled insertion into `CLAIMS.json`. |
| `verification/scripts/verify_session2_phase8_sync.py` | Reproduces the corrected arithmetic with `mpmath`, local `mp.dps = 80`. |

---

## Affected constants

| Constant / quantity | Status |
|---|---|
| `Delta* = 1.710 ± 0.015 GeV [A]` | unchanged |
| `gamma = 16.339 [A-]` | unchanged |
| `kappa = 1/2 [A]` | unchanged |
| `lambda_S = 5/12 [A]` | unchanged |
| `v = 47.7 MeV [A]` | unchanged |
| `E_T = 2.44 MeV [C]` | unchanged |
| `gamma_bare = 49/3` | staged as `[D]`, Stratum III |
| `gamma_pred = 16.338962439648224...` | staged as `[D]`, Stratum III |
| `[NO-GO-STEP5]` | staged as `[D]`, Stratum III |

---

## Claims Table

| Claim ID | Claim | Value | Evidence Tag | Stratum | Source | Status | Falsification Exposure |
|---|---:|---:|---|---|---|---|---|
| UIDT-S2-001 | Bare-gamma conjecture | `gamma_bare(Nc)=((2Nc+1)^2)/Nc`; `gamma_bare(3)=49/3` | `[D]` | III | PR #367 / Phase-8 intake | staged | Reject if required correction is negative, >0.012, or SU(4) scaling fails. |
| UIDT-S2-002 | Required positive correction | `Delta_gamma_required=17/3000` | `[D]` | III | PR #367 / verification script | staged | Reject L1 ansatz if first-principles correction is outside band. |
| UIDT-S4P1-001 | Tachyon threshold with canonical `E_T` | `k_crit=4*pi*E_T=30.6619442990... MeV` | `[D]` | III | PR #369 / corrected numerical audit | staged | Fails if regulator-independent Wetterich trace does not reproduce onset. |
| UIDT-S4P1-002 | S4-P1 induced VEV | `v_S4P1=47.5012798530... MeV` | `[D]` | III | PR #369 / corrected numerical audit | staged | Fails if full flow cannot recover canonical `v=47.7 MeV`. |
| UIDT-S4P1-003 | Non-perturbative gamma shift | `Delta_gamma_NP=0.00562910631489145...` | `[D]` | III | PR #369 / corrected numerical audit | staged | Fails if full Wetterich flow gives incompatible shift. |
| UIDT-S4P1-004 | S4-P1 gamma prediction | `gamma_pred=16.338962439648224...` | `[D]` | III | PR #369 / corrected numerical audit | staged | Fails if regulator-independence shifts prediction outside calibration band. |
| UIDT-S5-001 | `[NO-GO-STEP5]` LPA' NLO physical path | `Z_phi(IR, lambda3_phys)=1.0000019 != gamma` | `[D]` | III | PR #362 | staged | Overturned only by reproduced LPA'+Y/BMW derivation from physical `lambda3`. |

---

## Reproduction Note

```bash
python verification/scripts/verify_session2_phase8_sync.py
```

Expected:

```text
ALL SESSION-2 PHASE-8 SYNC CHECKS PASSED
```

---

## Verified References

| DOI/arXiv/PR | Status | Used for | Evidence Tag |
|---|---|---|---|
| DOI `10.5281/zenodo.17835200` | project DOI | UIDT canonical project identity | n/a |
| PR #367 | merged repository PR | gamma_bare Session-2 context | `[D]` |
| PR #369 | merged repository PR | S4-P1 tachyon-threshold chain | `[D]` |
| PR #362 | merged repository PR | `[NO-GO-STEP5]` | `[D]` |
| PR #358 | merged repository PR | L1/L4/L5 no-go context | `[D/E context]` |

No new external DOI/arXiv source is introduced by this sync.

---

## Quality Gate

- [x] No direct push to `main`
- [x] Ticket branch used
- [x] No protected `core/` or `modules/` numerical behavior changed
- [x] No `UIDT-OS/`, `.env`, credentials, or ignored internal paths touched
- [x] No evidence tag upgraded
- [x] `mp.dps = 80` local in verification script
- [x] No `float()` or `round()` in verification script
- [x] RG residual remains exactly zero
- [x] H₀/S₈/cosmology claims not declared resolved
- [x] `CLAIMS.json` not blindly rewritten; claims are staged in `LEDGER/SESSION2_PHASE8_CLAIMS_SYNC.md` for reviewer-controlled insertion

---

## Limitations

- L1 remains open: `gamma_bare=49/3` is not an `[A]` derivation.
- L4 remains open: S4-P1 is not a regulator-independent Wetterich proof.
- L5 remains open: N=99 is not derived by this sync.
- `gamma=16.339` remains `[A-]`.
- Historical `k_crit≈30.707 MeV` is not exact for `E_T=2.44 MeV`.
