### PR TITLE
Implement arXiv Falsification Radar & OPUS 4.7 Delegation

### DIFF
--- a/CANONICAL/FALSIFICATION.md
+++ b/CANONICAL/FALSIFICATION.md
@@ -15,6 +15,21 @@ The UIDT framework makes **testable predictions** across quantum field theory, l
 
 ---
 
+
+## AUTONOMOUS AGENT PROTOCOLS
+
+### OPUS 4.7 DELEGATION TRIGGER (Rule 3D)
+**Trigger:** Agents (e.g., Jules) detect a peer-reviewed paper that hits a known Falsification Trigger from `FALSIFICATION.md` or severely impacts `LIMITATIONS.md` (e.g., L1, L4, L5).
+**Action:** Jules is FORBIDDEN from downgrading Category [A] claims autonomously. Jules must generate an Emergency Epistemic Report for @Opus-4.7:
+> "🚨 **FALSIFICATION TRIGGER DETECTED:** ArXiv scan identified paper [DOI/arXiv]. Data implies [Threshold]. This challenges [Claim/Mechanism]. Requesting immediate Opus 4.7 evaluation for potential downgrade of Claim [X] to Category [E-withdrawn]."
+
+### THE AUDIT LOOP (Rule 4.1 & 4.2)
+- **Rule 4.1 (ArXiv Monitor):** Execute `LOCAL/scripts/arxiv_scan.py` weekly (Monday 06:00 UTC) to search for new papers related to:
+  - "Lattice QCD glueball spectrum continuum limit"
+  - "DESI dark energy equation of state"
+  - "Casimir effect anomaly precision measurement"
+- **Rule 4.2 (Data Parsing & CoVe):** Extract numerical findings from abstracts. If thresholds are met, generate the Opus 4.7 Emergency Epistemic Report.
+
 ## CRITICAL TESTS (Theory-Killing)
 
 ### F1: Lattice QCD Continuum Limit 🔴 HIGHEST PRIORITY

--- a/CANONICAL/LIMITATIONS.md
+++ b/CANONICAL/LIMITATIONS.md
@@ -186,7 +186,9 @@ If any of these occur, UIDT requires major revision:
 3. **DESI:** w = -1.00 ± 0.01 exactly (pure ΛCDM)
 4. **LHC:** Scalar excluded in 1.5-1.9 GeV window
 
-See `LEDGER/FALSIFICATION.md` for details.
+*Note: These triggers are continuously monitored via the autonomous execution of `LOCAL/scripts/arxiv_scan.py` (Rule 4.1). If an agent (e.g., Jules) detects a trigger, they are strictly forbidden from autonomously downgrading Category [A] claims. They must instead generate an Emergency Epistemic Report for @Opus-4.7 following Rule 3D.*
+
+See `CANONICAL/FALSIFICATION.md` for details.
 
 ---
 

--- a/LOCAL/logs/traceability.json
+++ b/LOCAL/logs/traceability.json
@@ -1,0 +1,17 @@
+{
+  "TKT-2026-05-18-ARXIV-SCAN-01": {
+    "files": [
+      "CANONICAL/FALSIFICATION.md",
+      "CANONICAL/LIMITATIONS.md",
+      "LOCAL/scripts/arxiv_scan.py"
+    ],
+    "tests": [],
+    "docs": [
+      "FALSIFICATION.md updated with Opus-4.7 trigger",
+      "LIMITATIONS.md falsification trigger updated to reference arxiv scan"
+    ],
+    "status": "implemented",
+    "timestamp": 1779116412,
+    "author": "P. Rietz"
+  }
+}

--- a/LOCAL/pr_template.md
+++ b/LOCAL/pr_template.md
@@ -1,0 +1,11 @@
+[UIDT-v3.9] Governance: Implement arXiv Falsification Radar & OPUS 4.7 Delegation
+### Objective
+Implemented `LOCAL/scripts/arxiv_scan.py` to continuously monitor arXiv for peer-reviewed papers matching Falsification Triggers. Also updated `CANONICAL/FALSIFICATION.md` and `CANONICAL/LIMITATIONS.md` to define Rule 3D (Opus 4.7 Delegation) and Rules 4.1 & 4.2 (Audit Loop), ensuring agents cannot autonomously downgrade Category [A] claims.
+
+### Evidence Status & Claims
+- Affected Constants: N/A
+- Evidence Category: N/A
+- Residual Check: N/A
+
+Author: P. Rietz
+Mode: OUTPUT-MODE

--- a/LOCAL/scripts/arxiv_scan.py
+++ b/LOCAL/scripts/arxiv_scan.py
@@ -1,0 +1,75 @@
+import urllib.request
+import urllib.parse
+import xml.etree.ElementTree as ET
+import re
+import os
+import time
+
+def generate_emergency_report(paper_id, threshold, claim_mechanism):
+    report_content = f"""🚨 **FALSIFICATION TRIGGER DETECTED:** ArXiv scan identified paper {paper_id}. Data implies {threshold}. This challenges {claim_mechanism}. Requesting immediate Opus 4.7 evaluation for potential downgrade of Claim [X] to Category [E-withdrawn]."""
+
+    logs_dir = "LOCAL/logs"
+    os.makedirs(logs_dir, exist_ok=True)
+    report_path = os.path.join(logs_dir, f"Emergency_Epistemic_Report_{int(time.time())}.md")
+    with open(report_path, "w") as f:
+        f.write(report_content)
+    print(f"Generated Emergency Epistemic Report at {report_path}")
+
+def search_arxiv(query):
+    encoded_query = urllib.parse.quote_plus(query)
+    url = f'http://export.arxiv.org/api/query?search_query=all:{encoded_query}&start=0&max_results=10'
+    for attempt in range(3):
+        try:
+            req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+            data = urllib.request.urlopen(req).read()
+            root = ET.fromstring(data)
+
+            results = []
+            for entry in root.findall('{http://www.w3.org/2005/Atom}entry'):
+                title = entry.find('{http://www.w3.org/2005/Atom}title').text
+                summary = entry.find('{http://www.w3.org/2005/Atom}summary').text
+                paper_id = entry.find('{http://www.w3.org/2005/Atom}id').text
+                results.append({'title': title, 'summary': summary, 'id': paper_id})
+            return results
+        except Exception as e:
+            print(f"Error fetching from arXiv: {e}")
+            time.sleep(5)
+    return []
+
+def scan():
+    print("Running arXiv Monitor (Rule 4.1 & 4.2)...")
+
+    queries = {
+        "desi": "DESI dark energy equation of state",
+        "lattice": "Lattice QCD glueball spectrum continuum limit",
+        "casimir": "Casimir effect anomaly precision measurement"
+    }
+
+    desi_pattern = re.compile(r'w\s*=\s*-1\.00\s*(?:\+/-|\\pm)\s*0\.01')
+    lattice_pattern = re.compile(r'mass gap.*!=.*1\.710.*>3\\sigma|mass gap.*\neq.*1\.710.*>3\\sigma')
+    casimir_pattern = re.compile(r'\\Delta F/F.*<.*0\.1%|anomaly.*<.*0\.1%')
+
+    for key, q in queries.items():
+        print(f"Querying: {q}")
+        papers = search_arxiv(q)
+        for p in papers:
+            summary = p['summary'].replace('\n', ' ')
+
+            if key == "desi":
+                if desi_pattern.search(summary):
+                    print(f"Trigger found in DESI paper: {p['id']}")
+                    generate_emergency_report(p['id'], r"w = -1.00 \pm 0.01", "the holographic scale factor mechanism")
+
+            elif key == "lattice":
+                if lattice_pattern.search(summary):
+                    print(f"Trigger found in Lattice paper: {p['id']}")
+                    generate_emergency_report(p['id'], r"mass gap != 1.710 GeV at >3\sigma", "Pillar I mass gap theorem")
+
+            elif key == "casimir":
+                if casimir_pattern.search(summary):
+                    print(f"Trigger found in Casimir paper: {p['id']}")
+                    generate_emergency_report(p['id'], r"|\Delta F/F| < 0.1%", "Casimir prediction")
+        time.sleep(3) # respectful to API rate limits
+
+if __name__ == "__main__":
+    scan()


### PR DESCRIPTION
Implemented `LOCAL/scripts/arxiv_scan.py` to continuously monitor arXiv for peer-reviewed papers matching Falsification Triggers. Also updated `CANONICAL/FALSIFICATION.md` and `CANONICAL/LIMITATIONS.md` to define Rule 3D (Opus 4.7 Delegation) and Rules 4.1 & 4.2 (Audit Loop), ensuring agents cannot autonomously downgrade Category [A] claims.

---
*PR created automatically by Jules for task [15267069424815570749](https://jules.google.com/task/15267069424815570749) started by @badbugsarts-hue*