### PR TITLE
research: Phase-8 P1 Pi_S diagrammatic kernel audit

### DIFF
--- a/docs/research/phase8_p1_pi_s_diagrammatic_kernel_2026-05-21.md
+++ b/docs/research/phase8_p1_pi_s_diagrammatic_kernel_2026-05-21.md
@@ -1,0 +1,233 @@
+# Phase-8 P1 Pi_S Diagrammatic Kernel Audit
+
+> **UIDT Framework:** v3.9 Canonical  
+> **Date:** 2026-05-21  
+> **Branch:** `TKT-2026-05-21-phase8-p1-pi-s-diagrammatic-kernel`  
+> **Stacked on:** PR #471 → PR #467 → PR #461 → PR #460 → PR #459  
+> **Status:** Diagrammatic kernel-structure audit. No evidence-category promotion.
+
+---
+
+## 1. Objective
+
+The P1 target remains:
+
+```text
+Delta_gamma_required = gamma - 49/3 = 17/3000
+```
+
+This note begins the actual kernel step by writing the diagrammatic structures implied by the canonical v3.9 coupling:
+
+```text
+L_int = -(kappa/4) S^2 Tr(F_{mu nu} F^{mu nu})
+```
+
+expanded around:
+
+```text
+S = v + h
+```
+
+This audit does not derive `gamma = 16.339`. It determines which kernel components are structurally present and what can or cannot be inferred from them without a regulator and renormalization prescription.
+
+---
+
+## 2. Tension Alert: v3.9 vs v4.1 Audit Form
+
+The canonical v3.9 coupling is quadratic in `S`:
+
+```text
+L_int(v3.9) = -(kappa/4) S^2 Tr(F F)
+```
+
+The v4.1 audit form sometimes uses a linear schematic operator:
+
+```text
+L_int(v4.1 audit) ~ (kappa/Lambda) S Tr(F F) Omega
+```
+
+These forms must not be silently merged. This audit uses the canonical v3.9 form only.
+
+Status: `[TENSION ALERT]` if later derivations switch to the linear form without explicitly stating the matching map.
+
+---
+
+## 3. Expansion Around the Vacuum
+
+With:
+
+```text
+S = v + h
+```
+
+one obtains:
+
+```text
+S^2 = v^2 + 2 v h + h^2
+```
+
+Therefore:
+
+```text
+L_int = -(kappa/4) v^2 Tr(F F)
+        -(kappa/2) v h Tr(F F)
+        -(kappa/4) h^2 Tr(F F)
+```
+
+The two relevant interaction structures are:
+
+| Term | Role | Momentum dependence |
+|---|---|---|
+| `h F F` | two-vertex bubble contribution to `Pi_S(p^2)` | yes |
+| `h^2 F F` | contact/tadpole contribution | p-independent at this level |
+
+The contact term can affect mass-like terms under a regulator, but it does not by itself generate the wave-function derivative needed for a kinetic `Delta_gamma` correction.
+
+---
+
+## 4. Euclidean Transverse Kernel
+
+For a scalar `h` coupled to two gauge bosons through `h F_{mu nu} F_{mu nu}`, the tree-level two-gauge-field tensor has the schematic Euclidean structure:
+
+```text
+V_{mu nu}(q,k) = (q·k) delta_{mu nu} - q_nu k_mu
+```
+
+A transverse gauge-field bubble numerator is then audited as:
+
+```text
+N(q,p) = V_{mu nu}(q,q+p) P_mu alpha(q) P_nu beta(q+p) V_alpha beta(q,q+p)
+```
+
+with transverse projectors:
+
+```text
+P_mu nu(q) = delta_mu nu - q_mu q_nu/q^2
+```
+
+A deterministic angular grid in the verifier checks:
+
+```text
+N(q,p) >= 0
+```
+
+for representative Euclidean momentum configurations at `p = Delta*`.
+
+This verifies sign-compatibility of the transverse numerator. It does not fix the renormalized sign of `Delta_gamma`; that still depends on regulator, subtraction, contact terms, and matching convention.
+
+---
+
+## 5. Dimensional Scale Test
+
+The canonical v3.9 `hFF` coefficient scales as:
+
+```text
+hFF coefficient = kappa*v/2
+```
+
+with:
+
+```text
+kappa = 1/2
+v = 47.7 MeV
+Delta* = 1710 MeV
+```
+
+A dimension-suppressed estimate contains the factor:
+
+```text
+(kappa*v/Delta*)^2
+```
+
+The verifier checks the conservative estimate:
+
+```text
+Delta_gamma_dim6 ~ d_A * alpha_s^2/(16*pi^2) * (kappa*v/Delta*)^2
+```
+
+This value is far below `17/3000`. Therefore the canonical dimension-suppressed bubble by itself cannot explain the correction without a large enhancement, a different matching convention, or a non-perturbative mechanism.
+
+Status: [E]/NO-GO for the naive dimension-suppressed estimate as a direct P1 solution.
+
+---
+
+## 6. Claims Table
+
+| Claim ID | Claim | Value | Evidence | Stratum | Status | Falsification Exposure |
+|---|---:|---:|---|---|---|---|
+| P8-P1-KER-001 | v3.9 expansion gives both `hFF` and `h^2FF` structures. | coefficients `kappa*v/2`, `kappa/4` | [A] algebra / [D] use | III | structural pass | Fails only if canonical coupling is changed. |
+| P8-P1-KER-002 | The transverse bubble numerator is non-negative on the deterministic Euclidean grid. | `min >= 0` | [D] | III | numerical structural pass | Does not fix renormalized sign. |
+| P8-P1-KER-003 | The contact `h^2FF` term is p-independent at this level. | qualitative | [D] | III | retained | Regulator terms may affect mass, not direct kinetic derivative. |
+| P8-P1-KER-004 | Naive dimension-suppressed canonical bubble is far too small. | enhancement required `>1000` | [E]/NO-GO | III | no-go for naive estimate | Overturned only by derived enhancement/matching. |
+| P8-P1-KER-005 | P1 self-energy correction is not derived. | — | [D] | III | open | Requires explicit regulator and subtraction prescription. |
+| P8-P1-KER-006 | v3.9 and v4.1 interaction forms must not be merged silently. | `[TENSION ALERT]` | process | III | active | Requires explicit matching map. |
+
+---
+
+## 7. Reproduction Note
+
+Single command:
+
+```bash
+python verification/scripts/verify_phase8_p1_pi_s_kernel_structure.py
+```
+
+Expected terminus:
+
+```text
+ALL PHASE-8 P1 PI_S KERNEL STRUCTURE CHECKS PASSED
+```
+
+---
+
+## 8. Verified References
+
+| DOI/arXiv/PR | Status | Used for | Evidence impact |
+|---|---|---|---|
+| DOI `10.5281/zenodo.17835200` | project DOI | UIDT project identity | n/a |
+| PR #471 | open / draft | prior P1 scale audit | [D] context |
+| arXiv `hep-th/0103195` | verified | optimized regulator context | no promotion |
+| arXiv `hep-lat/0404008` | verified | future SU(N) lattice comparison | no [B] claim here |
+
+The present result is an internal kernel-structure audit. No external source is used to promote a UIDT claim.
+
+---
+
+## 9. AI-Failure Audit
+
+| Failure mode | Check |
+|---|---|
+| Citation hallucination | No DOI invented; arXiv IDs verified before listing. |
+| Evidence inflation | Kernel results remain [D]/[E]. |
+| Proof-language overreach | No derivation of `gamma` is claimed. |
+| Hidden fitting | No new fitted coefficient is introduced. |
+| Symbol collision | Uses `Delta*` and avoids ambiguous `k_crit`. |
+| v3.9/v4.1 mixing | Explicit `[TENSION ALERT]` recorded. |
+| Numerical precision | `from mpmath import mp`, local `mp.dps = 80`. |
+| No-go honesty | Naive dimension-suppressed bubble is marked no-go. |
+
+---
+
+## 10. Result
+
+`P1 KERNEL STRUCTURE AUDIT COMPLETE / RENORMALIZED SELF-ENERGY STILL OPEN`
+
+The canonical v3.9 coupling provides a well-defined `hFF` bubble and an `h^2FF` contact term. The transverse Euclidean numerator is sign-compatible on the tested grid. However, the naive dimension-suppressed bubble is too small by more than three orders of magnitude and the renormalized `Delta_gamma` cannot be extracted without a regulator and subtraction prescription.
+
+---
+
+## 11. Next Logical Step
+
+The next P1 task should be:
+
+```text
+TKT-2026-05-21-phase8-p1-regulated-pi-s-integral
+```
+
+Required output:
+
+1. choose regulator explicitly;
+2. define subtraction point;
+3. compute `d Pi_S(p^2)/d p^2` or equivalent wave-function correction;
+4. compare residual to `17/3000`;
+5. preserve [D]/[E] unless proof-level and source-level gates are satisfied.

--- a/docs/research/phase8_p1_pi_s_diagrammatic_kernel_handover_2026-05-21.md
+++ b/docs/research/phase8_p1_pi_s_diagrammatic_kernel_handover_2026-05-21.md
@@ -1,0 +1,102 @@
+# Phase-8 P1 Pi_S Diagrammatic Kernel — Handover
+
+> **UIDT Framework:** v3.9 Canonical  
+> **Date:** 2026-05-21  
+> **Branch:** `TKT-2026-05-21-phase8-p1-pi-s-diagrammatic-kernel`  
+> **Status:** Handover note. No evidence-category promotion.
+
+---
+
+## Objective
+
+Start the actual P1 kernel step after the scale audit in PR #471:
+
+```text
+Pi_S(p^2) at p = Delta*
+```
+
+This task defines and checks the diagrammatic kernel structures implied by the canonical v3.9 coupling. It does not compute a renormalized self-energy correction.
+
+---
+
+## Files Added
+
+| Path | Purpose |
+|---|---|
+| `verification/scripts/verify_phase8_p1_pi_s_kernel_structure.py` | Reproducible 80-dps kernel-structure verifier. |
+| `docs/research/phase8_p1_pi_s_diagrammatic_kernel_2026-05-21.md` | Research report and claims table. |
+| `docs/research/phase8_p1_pi_s_diagrammatic_kernel_handover_2026-05-21.md` | This handover note. |
+
+---
+
+## Main Result
+
+The canonical v3.9 interaction:
+
+```text
+L_int = -(kappa/4) S^2 Tr(F F)
+```
+
+expanded around `S = v + h` gives:
+
+```text
+hFF coefficient   = kappa*v/2
+h^2FF coefficient = kappa/4
+```
+
+The `hFF` bubble is the relevant momentum-dependent kernel candidate. The `h^2FF` contact term is p-independent at this level and cannot by itself fix the kinetic correction.
+
+---
+
+## Numerical Findings
+
+| Check | Result | Status |
+|---|---:|---|
+| `Delta_gamma_required = 17/3000` | residual `<1e-70` | PASS |
+| Euclidean transverse bubble numerator | non-negative on deterministic grid | structural [D] pass |
+| naive dimension-suppressed canonical bubble | too small by `>1000` enhancement factor | [E]/NO-GO |
+| self-energy derivation | not obtained | OPEN |
+
+---
+
+## Tension Alert
+
+The canonical v3.9 interaction is quadratic in `S`. The v4.1 audit form is sometimes written as a linear `S Tr(F F)` structure. These forms must not be silently merged. Any later derivation must explicitly state its matching map.
+
+---
+
+## Reproduction Command
+
+```bash
+python verification/scripts/verify_phase8_p1_pi_s_kernel_structure.py
+```
+
+Expected terminus:
+
+```text
+ALL PHASE-8 P1 PI_S KERNEL STRUCTURE CHECKS PASSED
+```
+
+---
+
+## Next Required Task
+
+The next step is a regulated integral:
+
+```text
+TKT-2026-05-21-phase8-p1-regulated-pi-s-integral
+```
+
+Required outputs:
+
+1. regulator definition;
+2. subtraction point;
+3. derivative `d Pi_S(p^2)/d p^2` or equivalent wave-function correction;
+4. residual to `17/3000`;
+5. honest NO-GO if no coefficient is derived.
+
+---
+
+## Acceptance Status
+
+`KERNEL STRUCTURE AUDIT COMPLETE / RENORMALIZED SELF-ENERGY STILL OPEN`

--- a/verification/scripts/verify_phase8_p1_pi_s_kernel_structure.py
+++ b/verification/scripts/verify_phase8_p1_pi_s_kernel_structure.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""UIDT v3.9 Phase-8 P1 Pi_S kernel-structure audit.
+
+This script checks structural consequences of the canonical v3.9 coupling
+
+    L_int = -(kappa/4) S^2 Tr(F_{mu nu} F^{mu nu})
+
+expanded around S = v + h.  It does not derive gamma.  It verifies:
+
+1. the required correction Delta_gamma_required = 17/3000;
+2. the h F F and h^2 F F coefficient hierarchy;
+3. positivity of the Euclidean transverse two-gluon bubble numerator on a
+   deterministic angular grid;
+4. the scale mismatch of a dimension-suppressed canonical hFF bubble estimate;
+5. the need for an explicit regulator/renormalization/matching prescription.
+
+Evidence status: [D]/[E] only.  No [A] promotion.
+"""
+
+from __future__ import annotations
+
+from mpmath import mp
+
+
+DIM = 4
+
+
+def nstr(value: mp.mpf) -> str:
+    return mp.nstr(value, 80)
+
+
+def dot(a: list[mp.mpf], b: list[mp.mpf]) -> mp.mpf:
+    return mp.fsum(a[i] * b[i] for i in range(DIM))
+
+
+def projector(q: list[mp.mpf]) -> list[list[mp.mpf]]:
+    q2 = dot(q, q)
+    assert q2 > 0, "projector requires non-zero momentum"
+    return [
+        [
+            (mp.mpf(1) if mu == nu else mp.mpf(0)) - q[mu] * q[nu] / q2
+            for nu in range(DIM)
+        ]
+        for mu in range(DIM)
+    ]
+
+
+def hff_vertex_tensor(q: list[mp.mpf], k: list[mp.mpf]) -> list[list[mp.mpf]]:
+    qk = dot(q, k)
+    return [
+        [
+            qk * (mp.mpf(1) if mu == nu else mp.mpf(0)) - q[nu] * k[mu]
+            for nu in range(DIM)
+        ]
+        for mu in range(DIM)
+    ]
+
+
+def transverse_bubble_numerator(q: list[mp.mpf], p: list[mp.mpf]) -> mp.mpf:
+    k = [q[i] + p[i] for i in range(DIM)]
+    v = hff_vertex_tensor(q, k)
+    pq = projector(q)
+    pk = projector(k)
+    total = mp.mpf(0)
+    for mu in range(DIM):
+        for nu in range(DIM):
+            for alpha in range(DIM):
+                for beta in range(DIM):
+                    total += v[mu][nu] * pq[mu][alpha] * pk[nu][beta] * v[alpha][beta]
+    return total
+
+
+def classify_residual(value: mp.mpf, target: mp.mpf) -> str:
+    r = abs(value - target)
+    if r < mp.mpf("1e-14"):
+        return "PROOF_LEVEL_NUMERICAL_CLOSURE_REQUIRES_DERIVATION"
+    if r < mp.mpf("1e-3"):
+        return "PARTIAL_SCALE_HIT_D"
+    return "NO_GO_SCALE_MISMATCH_E"
+
+
+def main() -> None:
+    mp.dps = 80
+
+    nc = mp.mpf(3)
+    d_a = nc**2 - 1
+    gamma = mp.mpf("16.339")
+    gamma_bare = (2 * nc + 1) ** 2 / nc
+    delta_required = gamma - gamma_bare
+    delta_expected = mp.mpf(17) / mp.mpf(3000)
+    delta_residual = abs(delta_required - delta_expected)
+    assert delta_residual < mp.mpf("1e-70"), nstr(delta_residual)
+
+    kappa = mp.mpf(1) / mp.mpf(2)
+    v_mev = mp.mpf("47.7")
+    delta_star_mev = mp.mpf("1710")
+    alpha_s_ref = mp.mpf("0.326")
+
+    hff_coeff = kappa * v_mev / mp.mpf(2)
+    hhff_coeff = kappa / mp.mpf(4)
+    coeff_ratio = hff_coeff / hhff_coeff
+    assert coeff_ratio == 2 * v_mev
+
+    unit_2loop = alpha_s_ref**2 / (16 * mp.pi**2)
+    dimension_suppression = (kappa * v_mev / delta_star_mev) ** 2
+    canonical_dim6_bubble_estimate = d_a * unit_2loop * dimension_suppression
+    canonical_dim6_residual = abs(canonical_dim6_bubble_estimate - delta_required)
+    canonical_dim6_enhancement_required = delta_required / canonical_dim6_bubble_estimate
+
+    linear_audit_required_coefficient = delta_required / unit_2loop
+
+    p_mag = delta_star_mev
+    p = [p_mag, mp.mpf(0), mp.mpf(0), mp.mpf(0)]
+    q_magnitudes = [p_mag / 4, p_mag, 4 * p_mag]
+    cos_values = [mp.mpf("-0.75"), mp.mpf("-0.25"), mp.mpf("0.25"), mp.mpf("0.75")]
+    min_num = None
+    max_num = None
+    for q_mag in q_magnitudes:
+        for c in cos_values:
+            s = mp.sqrt(1 - c**2)
+            q = [q_mag * c, q_mag * s, mp.mpf(0), mp.mpf(0)]
+            num = transverse_bubble_numerator(q, p)
+            if min_num is None or num < min_num:
+                min_num = num
+            if max_num is None or num > max_num:
+                max_num = num
+            assert num >= -mp.mpf("1e-40"), nstr(num)
+
+    assert min_num is not None
+    assert max_num is not None
+    assert canonical_dim6_bubble_estimate > 0
+    assert canonical_dim6_residual > mp.mpf("1e-3")
+    assert canonical_dim6_enhancement_required > mp.mpf(1000)
+    assert linear_audit_required_coefficient > d_a
+
+    print("=== UIDT Phase-8 P1 Pi_S Kernel-Structure Audit ===")
+    print("gamma_bare:", nstr(gamma_bare))
+    print("Delta_gamma_required:", nstr(delta_required))
+    print("Delta_gamma_required_residual_to_17_over_3000:", nstr(delta_residual))
+    print("hFF_coefficient_kappa_v_over_2_MeV:", nstr(hff_coeff))
+    print("hhFF_coefficient_kappa_over_4:", nstr(hhff_coeff))
+    print("hFF_to_hhFF_ratio:", nstr(coeff_ratio))
+    print("Euclidean_transverse_numerator_min_grid:", nstr(min_num))
+    print("Euclidean_transverse_numerator_max_grid:", nstr(max_num))
+    print("unit_alpha_s2_over_16pi2:", nstr(unit_2loop))
+    print("dimension_suppression_(kappa_v_over_Delta)^2:", nstr(dimension_suppression))
+    print("canonical_dim6_bubble_estimate:", nstr(canonical_dim6_bubble_estimate))
+    print("canonical_dim6_bubble_residual:", nstr(canonical_dim6_residual))
+    print("canonical_dim6_status:", classify_residual(canonical_dim6_bubble_estimate, delta_required))
+    print("canonical_dim6_enhancement_required:", nstr(canonical_dim6_enhancement_required))
+    print("linear_audit_required_coefficient_if_no_dim6_suppression:", nstr(linear_audit_required_coefficient))
+    print("TENSION_ALERT: v3.9 S^2F^2 and v4.1 SFF audit forms must not be silently merged")
+    print("CONTACT_TADPOLE_NOTE: h^2AA contact is p-independent at this level and cannot by itself fix wave-function Delta_gamma")
+    print("P1_PI_S_KERNEL_NOT_DERIVED")
+    print("ALL PHASE-8 P1 PI_S KERNEL STRUCTURE CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This Draft PR continues the corrected Phase-8 P1 track after PR #471.

It is stacked on PR #471, which is stacked on PR #467 -> #461 -> #460 -> #459.

This PR does **not** derive `gamma = 16.339`. It defines and audits the diagrammatic kernel structures implied by the canonical v3.9 interaction

```text
L_int = -(kappa/4) S^2 Tr(F F)
```

expanded around `S = v + h`.

---

## Files changed

| File | Purpose |
|---|---|
| `verification/scripts/verify_phase8_p1_pi_s_kernel_structure.py` | Reproducible 80-dps kernel-structure verifier. |
| `docs/research/phase8_p1_pi_s_diagrammatic_kernel_2026-05-21.md` | Research report, claims table, no-go register. |
| `docs/research/phase8_p1_pi_s_diagrammatic_kernel_handover_2026-05-21.md` | Handover for the next regulated-integral task. |

---

## Main findings

| Finding | Evidence | Status |
|---|---|---|
| v3.9 expansion yields `hFF` and `h^2FF` structures. | [A] algebra / [D] use | structural pass |
| The Euclidean transverse bubble numerator is non-negative on a deterministic grid. | [D] | sign-compatible numerator only |
| The `h^2FF` contact term is p-independent at this level. | [D] | cannot alone fix kinetic `Delta_gamma` |
| Naive dimension-suppressed canonical bubble is too small by `>1000`. | [E]/NO-GO | direct naive estimate rejected |
| v3.9 `S^2FF` and v4.1 audit `SFF` forms must not be silently merged. | TENSION ALERT | matching map required |
| Renormalized `Pi_S` correction remains open. | [D] | next task required |

---

## Reproduction Note

```bash
python verification/scripts/verify_phase8_p1_pi_s_kernel_structure.py
```

Expected terminus:

```text
ALL PHASE-8 P1 PI_S KERNEL STRUCTURE CHECKS PASSED
```

---

## Claims Table

| Claim ID | Claim | Value | Evidence | Stratum | Status | Falsification Exposure |
|---|---:|---:|---|---|---|---|
| P8-P1-KER-001 | v3.9 expansion gives both `hFF` and `h^2FF` structures. | coefficients `kappa*v/2`, `kappa/4` | [A] algebra / [D] use | III | structural pass | Fails only if canonical coupling is changed. |
| P8-P1-KER-002 | The transverse bubble numerator is non-negative on the deterministic Euclidean grid. | `min >= 0` | [D] | III | numerical structural pass | Does not fix renormalized sign. |
| P8-P1-KER-003 | The contact `h^2FF` term is p-independent at this level. | qualitative | [D] | III | retained | Regulator terms may affect mass, not direct kinetic derivative. |
| P8-P1-KER-004 | Naive dimension-suppressed canonical bubble is far too small. | enhancement required `>1000` | [E]/NO-GO | III | no-go for naive estimate | Overturned only by derived enhancement/matching. |
| P8-P1-KER-005 | P1 self-energy correction is not derived. | — | [D] | III | open | Requires explicit regulator and subtraction prescription. |
| P8-P1-KER-006 | v3.9 and v4.1 interaction forms must not be merged silently. | `[TENSION ALERT]` | process | III | active | Requires explicit matching map. |

---

## Verified References

| DOI/arXiv/PR | Status | Used for | Evidence impact |
|---|---|---|---|
| DOI `10.5281/zenodo.17835200` | project DOI | UIDT project identity | n/a |
| PR #471 | open / draft | prior P1 scale audit | [D] context |
| arXiv `hep-th/0103195` | verified | optimized regulator context | no promotion |
| arXiv `hep-lat/0404008` | verified | future SU(N) lattice comparison | no [B] claim here |

No external source is used to promote a UIDT claim.

---

## Quality Gate

- [x] Draft PR only
- [x] Stacked on #471, not direct-to-main
- [x] No `CANONICAL/`, `LEDGER/CLAIMS.json`, `core/`, or `modules/` changes
- [x] No evidence category promotion
- [x] Local `mp.dps = 80` via `from mpmath import mp`
- [x] No `float()` or `round()`
- [x] No mocks or test doubles
- [x] v3.9/v4.1 form tension explicitly recorded
- [x] Honest NO-GO recorded for naive dimension-suppressed bubble

---

## Acceptance Status

`KERNEL STRUCTURE AUDIT COMPLETE / RENORMALIZED SELF-ENERGY STILL OPEN`

The next non-drift task is:

```text
TKT-2026-05-21-phase8-p1-regulated-pi-s-integral
```

with explicit regulator, subtraction point, derivative `d Pi_S(p^2)/d p^2`, and residual to `17/3000`.