### PR TITLE
research: Phase-8 P1 regulated Pi_S integral audit

### DIFF
--- a/docs/research/phase8_p1_regulated_pi_s_integral_2026-05-21.md
+++ b/docs/research/phase8_p1_regulated_pi_s_integral_2026-05-21.md
@@ -1,0 +1,216 @@
+# Phase-8 P1 Regulated Pi_S Integral Audit
+
+> **UIDT Framework:** v3.9 Canonical  
+> **Date:** 2026-05-21  
+> **Branch:** `TKT-2026-05-21-phase8-p1-regulated-pi-s-integral`  
+> **Stacked on:** PR #473 → PR #471 → PR #467 → PR #461 → PR #460 → PR #459  
+> **Status:** Regulated integral audit. No evidence-category promotion.
+
+---
+
+## 1. Objective
+
+This audit continues the P1 line from the diagrammatic-kernel PR. It evaluates a minimal Euclidean regulated `hFF` bubble model and asks whether the resulting wave-function-scale correction can reach:
+
+```text
+Delta_gamma_required = 17/3000
+```
+
+This is not a derivation of `gamma = 16.339`. It is a regulated no-go / scale test.
+
+---
+
+## 2. Regulator and Subtraction Point
+
+The audit uses a smooth Euclidean exponential regulator:
+
+```text
+R(q,k) = exp[-(q^2 + k^2)/Delta*^2]
+```
+
+with:
+
+```text
+k = q + p
+Lambda = Delta*
+y^2 = p^2 / Delta*^2
+subtraction point: y^2 = 1
+finite-difference step: delta y^2 = 0.01
+```
+
+The IR denominator uses:
+
+```text
+mu_IR = k_T / Delta*
+k_T = 4*pi*E_T
+```
+
+This is a model regulator. It is not claimed to be regulator-independent.
+
+---
+
+## 3. Kernel Definition
+
+The dimensionless regulated kernel is:
+
+```text
+J(y^2) = integral d^4q/(2*pi)^4
+         N(q,p) exp[-(q^2+(q+p)^2)]
+         /[(q^2+mu_IR^2)((q+p)^2+mu_IR^2)]
+```
+
+with the transverse numerator inherited from the previous kernel audit:
+
+```text
+N(q,p) = V_{mu nu}(q,q+p) P_mu alpha(q) P_nu beta(q+p) V_alpha beta(q,q+p)
+```
+
+and:
+
+```text
+V_{mu nu}(q,k) = (q*k) delta_{mu nu} - q_nu k_mu
+P_mu nu(q) = delta_mu nu - q_mu q_nu/q^2
+```
+
+The wave-function-scale diagnostic is:
+
+```text
+dJ/dy^2 at y^2 = 1
+```
+
+computed by a symmetric finite difference.
+
+---
+
+## 4. Numerical Result
+
+The verifier gives:
+
+```text
+J(1) ≈ 0.0016889012917009859
+dJ/dy^2|_{1} ≈ -0.0013885306847083777
+```
+
+The sign is convention-sensitive because the translation from `dJ/dy^2` to `Delta Z` depends on the renormalization convention. The audit therefore compares both signed and absolute scales.
+
+The canonical dimension-prefactor model is:
+
+```text
+d_A * alpha_s^2 * (kappa*v/Delta*)^2
+```
+
+and yields an absolute correction scale around:
+
+```text
+|Delta_gamma_model| ≈ 2.3e-7
+```
+
+against:
+
+```text
+Delta_gamma_required = 5.6666e-3
+```
+
+The required enhancement is approximately:
+
+```text
+~2.5e4
+```
+
+---
+
+## 5. Interpretation
+
+The regulated integral strengthens the no-go result from the previous kernel audit:
+
+1. The kernel is well-defined as a model integral.
+2. The derivative has a stable negative sign in this convention.
+3. The sign of `Delta Z` still requires an explicit renormalization convention.
+4. The magnitude is far too small under the canonical dimension-suppressed matching.
+5. Therefore the minimal smooth-regulated canonical bubble does not produce `17/3000`.
+
+Status: [E]/NO-GO for the minimal regulated model as a direct P1 solution.
+
+---
+
+## 6. Claims Table
+
+| Claim ID | Claim | Value | Evidence | Stratum | Status | Falsification Exposure |
+|---|---:|---:|---|---|---|---|
+| P8-P1-REG-001 | Smooth-regulated model kernel is explicitly defined. | `R=exp[-(q^2+k^2)/Delta*^2]` | [D] | III | PASS model definition | Different regulator may change the result. |
+| P8-P1-REG-002 | Subtraction point is fixed at `p^2=Delta*^2`. | `y^2=1` | [D] | III | PASS model definition | Different subtraction point may change the derivative. |
+| P8-P1-REG-003 | `dJ/dy^2` is negative in this convention. | about `-0.00138853` | [D] | III | numerical diagnostic | Sign of `Delta Z` depends on renormalization convention. |
+| P8-P1-REG-004 | Minimal dimension-suppressed model is too small. | `~2.3e-7` vs `5.666e-3` | [E]/NO-GO | III | NO-GO | Overturned only by derived enhancement/matching. |
+| P8-P1-REG-005 | Required enhancement is very large. | about `2.5e4` | [E]/NO-GO | III | fit-risk warning | Any enhancement must be derived, not fitted. |
+| P8-P1-REG-006 | P1 remains open. | — | [D] | III | open | Requires regulator-independent or explicitly matched derivation. |
+
+---
+
+## 7. Reproduction Note
+
+Single command:
+
+```bash
+python verification/scripts/verify_phase8_p1_regulated_pi_s_integral.py
+```
+
+Expected terminus:
+
+```text
+ALL PHASE-8 P1 REGULATED PI_S INTEGRAL CHECKS PASSED
+```
+
+---
+
+## 8. Verified References
+
+| DOI/arXiv/PR | Status | Used for | Evidence impact |
+|---|---|---|---|
+| DOI `10.5281/zenodo.17835200` | project DOI | UIDT project identity | n/a |
+| arXiv `hep-th/0103195` | verified | optimized regulator / FRG context | no UIDT claim promotion |
+| arXiv `hep-lat/0404008` | verified | future SU(N)/SU(4) lattice comparison context | no [B] claim here |
+| PR #473 | open / draft | prior kernel-structure audit | [D] context |
+
+---
+
+## 9. AI-Failure Audit
+
+| Failure mode | Check |
+|---|---|
+| Citation hallucination | No invented DOI/arXiv; external arXiv IDs verified before use. |
+| Evidence inflation | Result is [E]/NO-GO or [D] model diagnostic only. |
+| Proof-language overreach | No derivation of `gamma` claimed. |
+| Hidden fitting | Required enhancement is marked fit-risk, not introduced as a solution. |
+| Numerical precision | `from mpmath import mp`; local `mp.dps = 80`. |
+| Regulator ambiguity | Regulator and subtraction point explicitly stated. |
+| Sign ambiguity | Sign convention warning included. |
+| No-go documentation | Minimal regulated model documented as no-go. |
+
+---
+
+## 10. Result
+
+`REGULATED MODEL NO-GO / P1 STILL OPEN`
+
+The minimal smooth-regulated Euclidean bubble cannot generate the required correction under the canonical dimension-suppressed matching. A future path would need a derived non-perturbative matching enhancement, an alternative regulator with justified scheme dependence, or a different physical operator. None is established here.
+
+---
+
+## 11. Next Logical Step
+
+The next task should not tune the enhancement. It should compare regulator schemes or derive the missing matching factor.
+
+Recommended next task:
+
+```text
+TKT-2026-05-21-phase8-p1-regulator-comparison
+```
+
+Required output:
+
+1. Litim-style compact regulator;
+2. smooth exponential regulator;
+3. sharp cutoff diagnostic;
+4. same subtraction point;
+5. residual table to `17/3000`;
+6. no evidence promotion unless the result is regulator-stable and derived.

--- a/docs/research/phase8_p1_regulated_pi_s_integral_handover_2026-05-21.md
+++ b/docs/research/phase8_p1_regulated_pi_s_integral_handover_2026-05-21.md
@@ -1,0 +1,115 @@
+# Phase-8 P1 Regulated Pi_S Integral — Handover
+
+> **UIDT Framework:** v3.9 Canonical  
+> **Date:** 2026-05-21  
+> **Branch:** `TKT-2026-05-21-phase8-p1-regulated-pi-s-integral`  
+> **Status:** Handover note. No evidence-category promotion.
+
+---
+
+## Objective
+
+Continue the P1 line after the kernel-structure audit by evaluating a minimal regulated Euclidean bubble model for:
+
+```text
+Pi_S(p^2) at p = Delta*
+```
+
+The target correction remains:
+
+```text
+Delta_gamma_required = 17/3000
+```
+
+---
+
+## Files Added
+
+| Path | Purpose |
+|---|---|
+| `verification/scripts/verify_phase8_p1_regulated_pi_s_integral.py` | Reproducible 80-dps smooth-regulated integral audit. |
+| `docs/research/phase8_p1_regulated_pi_s_integral_2026-05-21.md` | Research report with regulator, subtraction point, claims table, and no-go result. |
+| `docs/research/phase8_p1_regulated_pi_s_integral_handover_2026-05-21.md` | This handover note. |
+
+---
+
+## Regulator and Subtraction
+
+Regulator:
+
+```text
+R(q,k) = exp[-(q^2 + k^2)/Delta*^2]
+```
+
+Subtraction point:
+
+```text
+y^2 = p^2/Delta*^2 = 1
+```
+
+Derivative diagnostic:
+
+```text
+dJ/dy^2 at y^2 = 1
+```
+
+---
+
+## Main Findings
+
+| Quantity | Result | Status |
+|---|---:|---|
+| `J(1)` | `~0.0016889013` | model diagnostic [D] |
+| `dJ/dy^2` | `~-0.0013885307` | sign convention warning [D] |
+| `|Delta_gamma_model|` | `~2.3e-7` | far below target |
+| required enhancement | `~2.5e4` | fit-risk / no-go |
+
+---
+
+## Interpretation
+
+The minimal smooth-regulated canonical bubble cannot generate `17/3000` under the tested dimension-suppressed matching. The sign of `Delta Z` still requires an explicit renormalization convention, but the magnitude deficit is already decisive for this minimal model.
+
+Status:
+
+```text
+REGULATED MODEL NO-GO / P1 STILL OPEN
+```
+
+---
+
+## Reproduction Command
+
+```bash
+python verification/scripts/verify_phase8_p1_regulated_pi_s_integral.py
+```
+
+Expected terminus:
+
+```text
+ALL PHASE-8 P1 REGULATED PI_S INTEGRAL CHECKS PASSED
+```
+
+---
+
+## Remaining Work
+
+The next task should compare regulator schemes or derive the missing matching factor:
+
+```text
+TKT-2026-05-21-phase8-p1-regulator-comparison
+```
+
+Required outputs:
+
+1. same subtraction point;
+2. smooth exponential, compact/Litim-style, and sharp-cutoff diagnostics;
+3. residual table to `17/3000`;
+4. no tuning of enhancement factors;
+5. no evidence promotion without derived regulator-stable result.
+
+---
+
+## Acceptance Status
+
+`REGULATED MODEL NO-GO / REGULATOR COMPARISON REQUIRED`

--- a/verification/scripts/verify_phase8_p1_regulated_pi_s_integral.py
+++ b/verification/scripts/verify_phase8_p1_regulated_pi_s_integral.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""UIDT v3.9 Phase-8 P1 regulated Pi_S integral audit.
+
+This script evaluates a minimal Euclidean regulated hFF bubble model for the
+canonical v3.9 interaction
+
+    L_int = -(kappa/4) S^2 Tr(F F),  S = v + h.
+
+It does not derive gamma. It checks the sign and scale of a regulated kernel
+under an explicit smooth cutoff and documents whether the result can reach
+Delta_gamma_required = 17/3000 without an additional matching enhancement.
+
+Evidence status: [D]/[E] only. No [A] promotion.
+"""
+
+from __future__ import annotations
+
+from mpmath import mp
+
+
+DIM = 4
+
+
+def nstr(value: mp.mpf) -> str:
+    return mp.nstr(value, 80)
+
+
+def dot(a: list[mp.mpf], b: list[mp.mpf]) -> mp.mpf:
+    return mp.fsum(a[i] * b[i] for i in range(DIM))
+
+
+def projector(q: list[mp.mpf]) -> list[list[mp.mpf]]:
+    q2 = dot(q, q)
+    assert q2 > 0, "projector requires non-zero momentum"
+    return [
+        [
+            (mp.mpf(1) if mu == nu else mp.mpf(0)) - q[mu] * q[nu] / q2
+            for nu in range(DIM)
+        ]
+        for mu in range(DIM)
+    ]
+
+
+def hff_vertex_tensor(q: list[mp.mpf], k: list[mp.mpf]) -> list[list[mp.mpf]]:
+    qk = dot(q, k)
+    return [
+        [
+            qk * (mp.mpf(1) if mu == nu else mp.mpf(0)) - q[nu] * k[mu]
+            for nu in range(DIM)
+        ]
+        for mu in range(DIM)
+    ]
+
+
+def transverse_bubble_numerator(q: list[mp.mpf], p: list[mp.mpf]) -> mp.mpf:
+    k = [q[i] + p[i] for i in range(DIM)]
+    vtx = hff_vertex_tensor(q, k)
+    pq = projector(q)
+    pk = projector(k)
+    total = mp.mpf(0)
+    for mu in range(DIM):
+        for nu in range(DIM):
+            for alpha in range(DIM):
+                for beta in range(DIM):
+                    total += vtx[mu][nu] * pq[mu][alpha] * pk[nu][beta] * vtx[alpha][beta]
+    return total
+
+
+def regulated_kernel_j(
+    y2: mp.mpf,
+    mu_ir: mp.mpf,
+    n_radial: int = 24,
+    n_angle: int = 24,
+    x_max: mp.mpf = mp.mpf(6),
+) -> mp.mpf:
+    """Dimensionless smooth-cutoff Euclidean bubble kernel.
+
+    y2 = p^2 / Lambda^2, x = |q| / Lambda, Lambda = Delta*.
+    Regulator: exp[-(q^2 + (q+p)^2)/Lambda^2].
+    IR denominator: (q^2 + mu_ir^2)((q+p)^2 + mu_ir^2).
+
+    The four-dimensional angular measure is reduced to
+    dOmega_3 = 4*pi*sqrt(1-c^2) dc.
+    """
+    assert y2 > 0
+    assert mu_ir > 0
+    y = mp.sqrt(y2)
+    dx = x_max / mp.mpf(n_radial)
+    dc = mp.mpf(2) / mp.mpf(n_angle)
+    prefactor = mp.mpf(1) / (4 * mp.pi**3)
+    p = [y, mp.mpf(0), mp.mpf(0), mp.mpf(0)]
+    total = mp.mpf(0)
+
+    for i in range(n_radial):
+        x = (mp.mpf(i) + mp.mpf("0.5")) * dx
+        for j in range(n_angle):
+            c = -mp.mpf(1) + (mp.mpf(j) + mp.mpf("0.5")) * dc
+            s = mp.sqrt(1 - c**2)
+            q = [x * c, x * s, mp.mpf(0), mp.mpf(0)]
+            k = [q[0] + p[0], q[1], mp.mpf(0), mp.mpf(0)]
+            q2 = dot(q, q)
+            k2 = dot(k, k)
+            numerator = transverse_bubble_numerator(q, p)
+            denominator = (q2 + mu_ir**2) * (k2 + mu_ir**2)
+            regulator = mp.exp(-(q2 + k2))
+            angular_weight = mp.sqrt(1 - c**2)
+            total += x**3 * angular_weight * numerator * regulator / denominator * dx * dc
+
+    return prefactor * total
+
+
+def derivative_wrt_y2(y2: mp.mpf, mu_ir: mp.mpf, step: mp.mpf) -> mp.mpf:
+    assert y2 - step > 0
+    return (regulated_kernel_j(y2 + step, mu_ir) - regulated_kernel_j(y2 - step, mu_ir)) / (2 * step)
+
+
+def main() -> None:
+    mp.dps = 80
+
+    nc = mp.mpf(3)
+    d_a = nc**2 - 1
+    gamma = mp.mpf("16.339")
+    gamma_bare = (2 * nc + 1) ** 2 / nc
+    delta_required = gamma - gamma_bare
+    expected_delta = mp.mpf(17) / mp.mpf(3000)
+    delta_residual = abs(delta_required - expected_delta)
+    assert delta_residual < mp.mpf("1e-70"), nstr(delta_residual)
+
+    kappa = mp.mpf(1) / mp.mpf(2)
+    v_mev = mp.mpf("47.7")
+    delta_star_mev = mp.mpf("1710")
+    e_t_mev = mp.mpf("2.44")
+    alpha_s_ref = mp.mpf("0.326")
+    k_t_mev = 4 * mp.pi * e_t_mev
+    mu_ir = k_t_mev / delta_star_mev
+
+    y2_subtraction = mp.mpf(1)
+    finite_difference_step = mp.mpf("0.01")
+    j0 = regulated_kernel_j(y2_subtraction, mu_ir)
+    j_prime = derivative_wrt_y2(y2_subtraction, mu_ir, finite_difference_step)
+
+    dimension_prefactor = d_a * alpha_s_ref**2 * (kappa * v_mev / delta_star_mev) ** 2
+    delta_gamma_model = dimension_prefactor * j_prime
+    delta_gamma_model_abs = abs(delta_gamma_model)
+    residual_signed = abs(delta_gamma_model - delta_required)
+    residual_abs = abs(delta_gamma_model_abs - delta_required)
+    enhancement_required_abs = delta_required / delta_gamma_model_abs
+
+    assert j0 > 0
+    assert j_prime < 0
+    assert delta_gamma_model < 0
+    assert delta_gamma_model_abs > 0
+    assert residual_abs > mp.mpf("1e-3")
+    assert enhancement_required_abs > mp.mpf("1000")
+
+    print("=== UIDT Phase-8 P1 Regulated Pi_S Integral Audit ===")
+    print("regulator:", "smooth_exp_exp_minus_q2_plus_k2_over_Lambda2")
+    print("subtraction_y2_p2_over_Delta2:", nstr(y2_subtraction))
+    print("finite_difference_step_y2:", nstr(finite_difference_step))
+    print("gamma_bare:", nstr(gamma_bare))
+    print("Delta_gamma_required:", nstr(delta_required))
+    print("Delta_gamma_required_residual_to_17_over_3000:", nstr(delta_residual))
+    print("k_T_mev:", nstr(k_t_mev))
+    print("mu_IR_kT_over_Delta:", nstr(mu_ir))
+    print("J_y2_equals_1:", nstr(j0))
+    print("dJ_dy2_at_y2_equals_1:", nstr(j_prime))
+    print("dimension_prefactor_dA_alpha2_kappav_over_Delta_squared:", nstr(dimension_prefactor))
+    print("Delta_gamma_model_signed:", nstr(delta_gamma_model))
+    print("Delta_gamma_model_abs:", nstr(delta_gamma_model_abs))
+    print("residual_signed_to_required:", nstr(residual_signed))
+    print("residual_abs_to_required:", nstr(residual_abs))
+    print("enhancement_required_abs:", nstr(enhancement_required_abs))
+    print("SIGN_NOTE: dJ/dy2 is negative in this convention; DeltaZ sign requires explicit renormalization convention")
+    print("NO_GO: minimal smooth-regulated canonical bubble is far below 17/3000 without extra matching enhancement")
+    print("P1_REGULATED_PI_S_INTEGRAL_NOT_DERIVED")
+    print("ALL PHASE-8 P1 REGULATED PI_S INTEGRAL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This Draft PR continues the corrected Phase-8 P1 line after PR #473.

It is stacked on PR #473, which is stacked on PR #471 -> #467 -> #461 -> #460 -> #459.

This PR evaluates a minimal regulated Euclidean `hFF` bubble model for

```text
Pi_S(p^2) at p = Delta*
```

with an explicit smooth cutoff and subtraction point. It does **not** derive `gamma = 16.339`.

---

## Files changed

| File | Purpose |
|---|---|
| `verification/scripts/verify_phase8_p1_regulated_pi_s_integral.py` | Reproducible 80-dps smooth-regulated integral audit. |
| `docs/research/phase8_p1_regulated_pi_s_integral_2026-05-21.md` | Research report with regulator, subtraction point, claims table, and no-go result. |
| `docs/research/phase8_p1_regulated_pi_s_integral_handover_2026-05-21.md` | Handover for the next regulator-comparison task. |

---

## Regulator and subtraction point

Regulator:

```text
R(q,k) = exp[-(q^2 + k^2)/Delta*^2]
```

Subtraction point:

```text
y^2 = p^2/Delta*^2 = 1
```

Derivative diagnostic:

```text
dJ/dy^2 at y^2 = 1
```

---

## Main findings

| Quantity | Result | Evidence | Status |
|---|---:|---|---|
| `J(1)` | `~0.0016889013` | [D] | model diagnostic |
| `dJ/dy^2` | `~-0.0013885307` | [D] | sign convention warning |
| `|Delta_gamma_model|` | `~2.3e-7` | [E]/NO-GO | far below target |
| required enhancement | `~2.5e4` | [E]/fit-risk | not promotable |
| P1 derivation | not obtained | [D] | open |

---

## Reproduction Note

```bash
python verification/scripts/verify_phase8_p1_regulated_pi_s_integral.py
```

Expected terminus:

```text
ALL PHASE-8 P1 REGULATED PI_S INTEGRAL CHECKS PASSED
```

---

## Claims Table

| Claim ID | Claim | Value | Evidence | Stratum | Status | Falsification Exposure |
|---|---:|---:|---|---|---|---|
| P8-P1-REG-001 | Smooth-regulated model kernel is explicitly defined. | `R=exp[-(q^2+k^2)/Delta*^2]` | [D] | III | PASS model definition | Different regulator may change the result. |
| P8-P1-REG-002 | Subtraction point is fixed at `p^2=Delta*^2`. | `y^2=1` | [D] | III | PASS model definition | Different subtraction point may change the derivative. |
| P8-P1-REG-003 | `dJ/dy^2` is negative in this convention. | about `-0.00138853` | [D] | III | numerical diagnostic | Sign of `Delta Z` depends on renormalization convention. |
| P8-P1-REG-004 | Minimal dimension-suppressed model is too small. | `~2.3e-7` vs `5.666e-3` | [E]/NO-GO | III | NO-GO | Overturned only by derived enhancement/matching. |
| P8-P1-REG-005 | Required enhancement is very large. | about `2.5e4` | [E]/NO-GO | III | fit-risk warning | Any enhancement must be derived, not fitted. |
| P8-P1-REG-006 | P1 remains open. | — | [D] | III | open | Requires regulator-independent or explicitly matched derivation. |

---

## Verified References

| DOI/arXiv/PR | Status | Used for | Evidence impact |
|---|---|---|---|
| DOI `10.5281/zenodo.17835200` | project DOI | UIDT project identity | n/a |
| arXiv `hep-th/0103195` | verified | optimized regulator / FRG context | no UIDT claim promotion |
| arXiv `hep-lat/0404008` | verified | future SU(N)/SU(4) lattice comparison context | no [B] claim here |
| PR #473 | open / draft | prior kernel-structure audit | [D] context |

---

## Quality Gate

- [x] Draft PR only
- [x] Stacked on #473, not direct-to-main
- [x] No `CANONICAL/`, `LEDGER/CLAIMS.json`, `core/`, or `modules/` changes
- [x] No evidence category promotion
- [x] Explicit regulator and subtraction point
- [x] Local `mp.dps = 80` via `from mpmath import mp`
- [x] No `float()` or `round()`
- [x] No mocks or test doubles
- [x] Sign-convention warning included
- [x] Honest NO-GO recorded for minimal smooth-regulated model

---

## Acceptance Status

`REGULATED MODEL NO-GO / P1 STILL OPEN`

The next non-drift task is regulator comparison:

```text
TKT-2026-05-21-phase8-p1-regulator-comparison
```

with smooth exponential, compact/Litim-style, and sharp-cutoff diagnostics under the same subtraction point.