### PR TITLE
[UIDT-v3.9] Cosmology: Add daily monitoring log for 2026-05-22

### DIFF
--- a/monitoring/cosmology_watch_2026-05-22.md
+++ b/monitoring/cosmology_watch_2026-05-22.md
@@ -1,0 +1,17 @@
+# Cosmology Watch Log 2026-05-22
+Operator: Jules (ALPHA-04)
+
+## DESI/Cosmology New Findings
+
+| Source | Parameter | Value | Uncertainty | UIDT Ledger | Tension σ | Alert |
+|--------|-----------|-------|-------------|-------------|-----------|-------|
+| DESI DR2 (DESI+CMB) | w₀ | -0.752 | ±0.057 | -0.99 | 4.18σ | [TENSION ALERT] |
+| DES Final (BAO+SNe+CMB) (arXiv:2605.09560) | w₀ | -0.673 | ±0.098 | -0.99 | 3.23σ | [TENSION ALERT] |
+
+## Status
+- H₀ tension: ONGOING (not resolved)
+- S₈ tension: ONGOING (not resolved)
+- w₀ UIDT alignment: Tension > 2σ found in both DESI DR2 and DES Final
+
+## Action Required
+[TENSION ALERT] issued for DESI DR2 and DES Final w₀ measurements against UIDT Canonical w₀ = -0.99 [C].


### PR DESCRIPTION
Add the daily cosmology watch log containing findings of w0 measurements from DESI DR2 and DES Final, noting their >2sigma tension with UIDT's canonical w0 value.

---
*PR created automatically by Jules for task [16248634352128587866](https://jules.google.com/task/16248634352128587866) started by @badbugsarts-hue*