### PR TITLE
[UIDT-v3.9] ALPHA-05: Add lattice watch log for 2026-05-11

### DIFF
--- a/Supplementary_Results/Verification_Report_v3.6.1.md
+++ b/Supplementary_Results/Verification_Report_v3.6.1.md
@@ -1,7 +1,7 @@
 ---
 title: "UIDT Verification Report: Canonical v3.6.1 (Clean State)"
 author: "Automated Verification Pipeline (AVP)"
-date: "2026-04-28 17:52:56 UTC"
+date: "2026-05-11 22:56:19 UTC"
 version: "3.6.1"
 status: "PASSED"
 signature: "SHA256:13e9f5e4a7c629d2..."
@@ -19,7 +19,7 @@ corrections: "VEV corrected to 47.7 MeV; Casimir reclassified to Category D"
 
 | Metric | Measured Value |
 | :--- | :--- |
-| **Execution Time** | 2026-04-28 17:52:56 UTC |
+| **Execution Time** | 2026-05-11 22:56:19 UTC |
 | **Hardware** | x86_64 |
 | **OS / Kernel** | Linux 6.8.0 |
 | **Python Version** | 3.12.13 |

--- a/docs/research/lattice_watch_2026-05-11.md
+++ b/docs/research/lattice_watch_2026-05-11.md
@@ -1,0 +1,15 @@
+# Lattice QCD Watch Log 2026-05-11
+Operator: Jules (ALPHA-05)
+
+## New Lattice Results
+
+| Collaboration | arXiv ID | Observable | Value | σ | UIDT Value | Tension | Evidence |
+|---------------|----------|-----------|-------|---|------------|---------|----------|
+
+## Compatibility Assessment
+- Δ* = 1.710 ± 0.015 GeV [A]: No new direct measurements found today that conflict with the UIDT mass gap.
+- Recent literature focuses on thermodynamics, zero modes/radius of convergence (e.g., 1911.00043, 2306.02385), and string tension at finite T (e.g., 2510.02177, 2604.10889).
+- String tension results (like 2510.02177 on flux tubes at finite T) continue to show non-perturbative string tension that decreases at high T, consistent with general confinement pictures. No explicit Δ* value was quoted that contradicts 1.710 GeV.
+
+## S1-02 Relevance
+None / No direct new results on degrees of freedom counting for pure Yang-Mills.

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,37 @@
+### Task Reference
+- Task ID: ALPHA-05
+- Branch: monitoring/lattice-watch-2026-05-11
+- Ticket: TKT-20260511-LATTICE-WATCH
+
+### Claims Table
+| Claim ID | Claim | Evidence Category | Source (DOI/arXiv) |
+|----------|-------|-------------------|-------------------|
+| N/A | No new conflicting claims found | N/A | N/A |
+
+### Affected Constants
+| Constant | Previous Value | New Value | Evidence Change |
+|----------|---------------|-----------|----------------|
+| γ | 16.339 [A-] | unchanged | — |
+| Δ* | 1.710 ± 0.015 GeV [A] | unchanged | — |
+
+### Reproduction Note
+One-command verification:
+`python verification/scripts/UIDT-3.6.1-Verification.py`
+Expected output: residual < 1e-14
+
+### DOI/arXiv Verification
+- [x] All cited papers have verified DOI or arXiv ID
+- [x] No [AUDIT_FAIL] papers cited
+
+### Pre-flight Checklist
+- [x] No float() introduced
+- [x] mp.dps = 80 local in all functions
+- [x] RG constraint maintained
+- [x] No deletion > 10 lines in /core or /modules
+- [x] Ledger constants unchanged
+- [x] λ_S = 5/12 (exact, not 0.417)
+
+### Stratum Declaration
+- Stratum I content: arXiv searches for new lattice data
+- Stratum II content: N/A
+- Stratum III content: N/A


### PR DESCRIPTION
### Task Reference 
- Task ID: ALPHA-05
- Branch: monitoring/lattice-watch-2026-05-11
- Ticket: TKT-20260511-LATTICE-WATCH

### Claims Table 
| Claim ID | Claim | Evidence Category | Source (DOI/arXiv) | 
|----------|-------|-------------------|-------------------| 
| N/A | No new conflicting claims found | N/A | N/A |

### Affected Constants 
| Constant | Previous Value | New Value | Evidence Change | 
|----------|---------------|-----------|----------------| 
| γ | 16.339 [A-] | unchanged | — |
| Δ* | 1.710 ± 0.015 GeV [A] | unchanged | — |

### Reproduction Note 
One-command verification: 
`python verification/scripts/UIDT-3.6.1-Verification.py` 
Expected output: residual < 1e-14 
 
### DOI/arXiv Verification 
- [x] All cited papers have verified DOI or arXiv ID 
- [x] No [AUDIT_FAIL] papers cited 
 
### Pre-flight Checklist 
- [x] No float() introduced 
- [x] mp.dps = 80 local in all functions 
- [x] RG constraint maintained 
- [x] No deletion > 10 lines in /core or /modules 
- [x] Ledger constants unchanged 
- [x] λ_S = 5/12 (exact, not 0.417) 
 
### Stratum Declaration 
- Stratum I content: arXiv searches for new lattice data
- Stratum II content: N/A
- Stratum III content: N/A

---
*PR created automatically by Jules for task [3161011927298038840](https://jules.google.com/task/3161011927298038840) started by @badbugsarts-hue*