### PR TITLE
docs: line-aware proof-language cleanup (TKT-2026-05-25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@
 >
 > UIDT is an **active research framework**, not established or peer-reviewed physics. Its central results have not yet been evaluated by an independent external body (e.g., Clay Mathematics Institute). Category A designations refer to **internal mathematical consistency** (Banach fixed-point closure, 80-digit residuals < 10⁻¹⁴), not to external validation. Cosmological parameters (Pillars II–IV) are calibrated against DESI/JWST data and carry Category C or D status. Known open problems are documented in the Limitations section below. The framework is designed to be falsifiable; the Kill-Switch matrix defines explicit refutation thresholds.
 
+> [!CAUTION]
+> **Numerical Transparency Statement**
+>
+> UIDT verification scripts use high-precision arithmetic to enforce reproducibility of the stated algebraic systems. An 80-digit calculation is a numerical integrity control, not a claim that the corresponding physical observable is known to 80-digit experimental accuracy. Category [A] claims are restricted to internally specified mathematical subsystems, such as reduced-model residual closure or exact algebraic constraints. Category [D] predictions remain unverified until independently measured. Category [E] interpretive mappings remain model hypotheses, especially when fitted parameters are required. The repository therefore treats high-precision numerics as a controlled mathematical clean room: deviations between the reduced model and empirical systems must be reported rather than absorbed by undocumented tuning.
+
 ---
 
 **Central Result:** Effective phenomenological derivation of a Yang-Mills spectral scale Δ* ≈ 1.710 GeV [A, internal reduced-model closure] through information-geometric coupling. The Banach contraction and residual closure apply to the reduced algebraic model; the projection to the full pure Yang-Mills functional integral remains an open Stratum III assumption [E].

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@
 
 ---
 
-**Central Result:** Analytical derivation of Yang-Mills mass gap Δ* ≈ 1.710 GeV (spectral gap) through information-geometric coupling, achieving mathematical closure with residuals < 10⁻⁴⁰.
+**Central Result:** Effective phenomenological derivation of a Yang-Mills spectral scale Δ* ≈ 1.710 GeV [A, internal reduced-model closure] through information-geometric coupling. The Banach contraction and residual closure apply to the reduced algebraic model; the projection to the full pure Yang-Mills functional integral remains an open Stratum III assumption [E].
 
-**Physical Significance:** Addresses the 10¹²⁰ vacuum energy hierarchy via γ⁻¹² suppression mechanism combined with holographic normalization (π⁻²), reducing the cosmological constant problem to 3.3% precision *within the UIDT model*. Introduces the Lattice Torsion Binding Energy (2.44 MeV) to stabilize the discrete vacuum structure.
+**Physical Significance:** Provides an evidence-tagged mapping between the reduced UIDT scale, calibrated γ-sector, lattice-compatible Yang-Mills observables, and calibrated cosmological parameters. The framework does not claim to solve the cosmological constant problem or the Clay Yang-Mills problem.
 
 **Falsification Threshold:** Five independent experimental pathways with specific numerical predictions:
 - Casimir anomaly +0.59% at 0.66 nm (Category D: **predicted, unverified**)
-- Glueball resonance at 1.705 ± 0.015 GeV (Category B: lattice-consistent)
+- Yang-Mills spectral scale Δ* = 1.710 ± 0.015 GeV [A/B-context] and tensor-glueball hierarchy m₂⁺⁺/m₀⁺⁺ = 1.354 [D]
 - Absence of Torsion Energy (E_T → 0) in precision hadron spectroscopy (Category A)
 - DESI dark energy evolution w₀ = −0.99 [C] (Canonical per Decision D-002, DESI-calibrated)
 - Photonic isomorphism transition at n_critical = γ ≈ 16.339 (Category D: analog verification)
@@ -54,8 +54,11 @@
 - [`verification/`](./verification) — reproducibility and verification scripts
 
 ### Recommended technical documents
+- [`docs/theory/effective_gap_derivation.md`](./docs/theory/effective_gap_derivation.md)
 - [`docs/theory/bare_gamma_theorem.md`](./docs/theory/bare_gamma_theorem.md)
 - [`docs/theory/cosmological_implications_v3.9.md`](./docs/theory/cosmological_implications_v3.9.md)
+- [`docs/predictions/glueball_spectrum.md`](./docs/predictions/glueball_spectrum.md)
+- [`docs/predictions/thermal_vacuum.md`](./docs/predictions/thermal_vacuum.md)
 - [`docs/evidence/falsification-criteria.md`](./docs/evidence/falsification-criteria.md)
 - [`docs/evidence/evidence-classification.md`](./docs/evidence/evidence-classification.md)
 - [`docs/research/experimental_roadmap.md`](./docs/research/experimental_roadmap.md)
@@ -77,15 +80,15 @@
 
 **UIDT v3.9 presents a constructive, high-precision framework for the information-geometric coupling of QFT-sector observables and gravitational parameters.**
 
-By introducing vacuum information density as a fundamental scalar field $S(x)$, the theory derives the Yang-Mills Mass Gap and constrains the vacuum energy hierarchy. This **Complete Manuscript** establishes the **Four-Pillar Architecture** and synthesizes the framework with the **Covariant Scalar-Field (CSF)** formalism, a topological Lattice Torsion model, and a photonic analog platform.
+By introducing vacuum information density as an effective scalar field $S(x)$, the framework documents a reduced-model Yang-Mills spectral scale and constrains the vacuum energy hierarchy inside the UIDT model. This **Complete Manuscript** establishes the **Four-Pillar Architecture** and synthesizes the framework with the **Covariant Scalar-Field (CSF)** formalism, a topological Lattice Torsion model, and a photonic analog platform.
 
-Canonical parameters are derived self-consistently via the **Extended Functional Renormalization Group (FRG)** and the **Banach Fixed-Point Theorem**. The solution yields the unique stable vacuum state at **$\Delta = 1.710$ GeV**, demonstrating numerical closure with residuals $< 10^{-40}$.
+Canonical parameters are organized self-consistently via the **Extended Functional Renormalization Group (FRG)** and a **Banach Fixed-Point closure** of the reduced algebraic gap equation. The reduced solution yields a stable effective spectral scale at **$\Delta = 1.710$ GeV** [A, internal reduced-model closure], while the mapping to pure Yang-Mills remains an open Stratum III assumption [E].
 
 ### 🔬 Core Derived Constants (Immutable)
 
 | Constant | Value | Evidence | Status |
 |----------|-------|----------|--------|
-| **Yang-Mills Mass Gap (Δ)** | 1.710 ± 0.015 GeV | A | Internal mathematical consistency |
+| **Yang-Mills spectral scale (Δ)** | 1.710 ± 0.015 GeV | A | Internal reduced-model consistency |
 | **Universal Gamma Invariant (γ)** | 16.339 (exact) | A− | Calibrated via Kinetic VEV |
 | **Lattice Torsion Binding Energy (E_T)** | 2.44 MeV | C | DESI-calibrated; L2 open |
 | **Holographic Length (λ)** | 0.66 nm | C | DESI-calibrated |
@@ -118,9 +121,9 @@ Canonical parameters are derived self-consistently via the **Extended Functional
 } }%%
 graph LR
 
-  subgraph LEVEL_0_1 ["Level 0: Axiom & Level 1: Core Theorem"]
+  subgraph LEVEL_0_1 ["Level 0: Axiom & Level 1: Reduced-Model Closure"]
     S["Vacuum Scalar Field S(x)"]
-    Banach["Banach Fixed Point"]
+    Banach["Reduced Banach Fixed Point"]
     Delta["Delta* = 1.710 ± 0.015 GeV [A]"]
     RG["5κ² = 3λ_S [A]"]
     Res["Residuals < 1e-14 [A]"]
@@ -131,7 +134,7 @@ graph LR
   end
 
   S -->|Coupling κ| Banach
-  Banach -->|Proof| Delta
+  Banach -->|Closure| Delta
   Banach -->|Verification| Res
   Delta -->|Constraint| RG
   RG --> Kappa
@@ -173,7 +176,7 @@ graph LR
     X17["X17 Noise Floor = 17.10 MeV [D]"]
     X2370["X2370 Resonance = 2.370 GeV [D]"]
     Casimir["Casimir +0.59% at 0.66 nm [D]"]
-    GlueTensor["Glueball Tensor = 2.418 GeV [D]"]
+    GlueTensor["Glueball Tensor = 2.3145 GeV [D]"]
   end
 
   subgraph PILLAR_IV ["🏛 Pillar IV: Photonic Isomorphism [D]"]
@@ -264,9 +267,9 @@ graph LR
 
 ### Pillar I: QFT Foundation (The Mathematical Core)
 
-* **Achievement:** Constructive proof of the Yang-Mills Mass Gap via non-minimal coupling
-* **Result:** Δ = 1.710 GeV (self-consistent solution)
-* **Verification:** Validated by the **Banach Fixed-Point Theorem** (Contraction mapping)
+* **Achievement:** Constructive framework for an effective Yang-Mills spectral scale via non-minimal coupling
+* **Result:** Δ = 1.710 GeV (reduced-model self-consistent solution)
+* **Verification:** Validated internally by the **Banach Fixed-Point Theorem** applied to the reduced algebraic map
 * **Status:** **Category A (Internal Mathematical Consistency)**
 
 > [!NOTE]
@@ -278,22 +281,22 @@ graph LR
 Three-Equation System Closure:
   Residuals: < 10⁻⁴⁰ (machine precision)
   Monte Carlo validation: 100,000 samples, all posteriors Gaussian
-  Lattice QCD agreement: z-score ≈ 0 (exact match with Chen et al. 2006)
+  Lattice QCD comparison: compatible scale within documented uncertainty conventions
 ```
 
 ### Pillar II: Lattice Topology & The Missing Link
 
 * **Achievement:** Replaces phenomenological vacuum-frequency constraints with thermodynamic derivations.
 * **Mechanism:** Derives the **Lattice Torsion Binding Energy (E_T = 2.44 MeV)**, mathematically bridging the purely geometric QFT resonance (104.7 MeV) to the observed stable vacuum frequency (107.1 MeV) required to prevent discrete lattice collapse.
-* **Vacuum Energy:** Addresses the 10¹²⁰ catastrophe via a 99-Step RG Cascade (γ⁻¹² scaling) and Holographic Normalization (π⁻²) — *within the UIDT model; external verification pending.*
+* **Vacuum Energy:** Models the 10¹²⁰ hierarchy via a 99-Step RG Cascade (γ⁻¹² scaling) and Holographic Normalization (π⁻²) within the UIDT model; external verification remains open.
 * **Status:** **Category A/C**
 
 ### Pillar III: Spectral Expansion & Thermodynamic Censorship
 
 * **Achievement:** Falsifiable predictions for precision and collider experiments.
 * **Predictions:**
-* **Thermodynamic Censorship (Wolpert Limit):** Formalizes the fundamental noise floor at **17.10 MeV**, providing an analytical origin for the **X17 anomaly**.
-* **Blind Resonances:** Predicts the BESIII **X2370 resonance** as a harmonic overtone, alongside higher glueball states (Tensor at 2.418 GeV).
+* **Thermodynamic Censorship (Wolpert Limit):** Formalizes the fundamental noise floor at **17.10 MeV**, providing a proposed analytical origin for the **X17 anomaly**.
+* **Resonance Sector:** Predicts the BESIII **X2370 resonance** as a harmonic overtone, alongside higher glueball-sector states (effective tensor estimate at 2.3145 GeV [D]).
 * **Casimir Anomaly:** +0.59% deviation at 0.66 nm (**Category D**).
 * **Status:** **Category D (Prediction Awaiting Verification)**
 
@@ -313,7 +316,7 @@ All claims are strictly classified by evidence strength:
 | Category | Description | Example |
 | --- | --- | --- |
 | **A (Internal Theorem)** | Mathematical self-consistency verified at 80-digit precision | Three-equation closure (residuals < 10⁻⁴⁰) |
-| **B (Lattice Consistent)** | Agreement with independent QCD simulations | Δ = 1.710 GeV (z-score ≈ 0 vs. lattice) |
+| **B (Lattice Consistent)** | Agreement with independent QCD simulations | Δ = 1.710 GeV as lattice-compatible scale |
 | **C (Calibrated Model)** | Dependent on DESI/JWST calibration | H₀, λ_UIDT from global fit |
 | **D (Unverified Prediction)** | Awaiting experimental confirmation | **X17 origin, X2370 resonance, Casimir anomaly** |
 
@@ -409,7 +412,7 @@ UIDT v3.9 is strictly falsifiable. The theory is considered refuted if:
 
 | Component | Status | Evidence | Note |
 |---|---|---|---|
-| Yang-Mills Mass Gap derivation | Internal proof complete | A | Independent peer review and Clay evaluation pending |
+| Yang-Mills effective gap derivation | Reduced-model closure | A | Pure-theory equivalence and Clay evaluation remain open |
 | Lattice Torsion Binding Energy (2.44 MeV) | Calibrated | C | "Missing Link" — DESI-anchored |
 | X17 Anomaly origin | Unverified prediction | D | Consistent with Thermodynamic Censorship at 17.10 MeV |
 | CSF-UIDT Unification | Covariant path defined | D | Formal synthesis in progress |

--- a/clay-submission/01_Manuscript/main.tex
+++ b/clay-submission/01_Manuscript/main.tex
@@ -1,12 +1,12 @@
 %=============================================================================
-% UIDT v3.6.1 — CLAY MATHEMATICS INSTITUTE SUBMISSION
-% A Constructive Proof of the Yang-Mills Mass Gap
+% UIDT v3.9 — EFFECTIVE GAP DERIVATION DOSSIER
+% An Effective Phenomenological Derivation of the Yang-Mills Scale
 % MODULAR VERSION - Uses \input for Appendices
 %=============================================================================
 % Author: Philipp Rietz (ORCID: 0009-0007-4307-1609)
 % DOI: 10.5281/zenodo.17835200
 % License: CC BY 4.0
-% Version: 3.6.1 (December 2025)
+% Version: 3.9 (May 2026)
 %=============================================================================
 % 
 % NOTE: This is the MODULAR version. 
@@ -97,8 +97,8 @@
 %-----------------------------------------------------------------------------
 \pagestyle{fancy}
 \fancyhf{}
-\fancyhead[L]{\small UIDT v3.6.1 --- Yang-Mills Mass Gap}
-\fancyhead[R]{\small Clay Mathematics Institute Submission}
+\fancyhead[L]{\small UIDT v3.9 --- Effective Yang-Mills Scale}
+\fancyhead[R]{\small Phenomenological Derivation Dossier}
 \fancyfoot[C]{\thepage}
 
 %-----------------------------------------------------------------------------
@@ -106,10 +106,10 @@
 %-----------------------------------------------------------------------------
 \title{%
 \vspace{-2cm}
-{\large Clay Mathematics Institute --- Millennium Prize Problem}\\[0.5cm]
-\textbf{A Constructive Proof of the Yang-Mills Mass Gap}\\[0.3cm]
-{\large via Information-Density Scalar Field Extension}\\[0.5cm]
-{\normalsize UIDT Framework v3.6.1}
+{\large UIDT Framework v3.9 --- Effective Yang-Mills Scale Dossier}\\[0.5cm]
+\textbf{An Effective Phenomenological Derivation of the Yang-Mills Scale}\\[0.3cm]
+{\large via Hybrid Information-Density Projection}\\[0.5cm]
+{\normalsize Evidence-tagged version; no Clay-level proof claim}
 }
 
 \author{%
@@ -118,7 +118,7 @@ Philipp Rietz\\
 \small DOI: 10.5281/zenodo.17835200
 }
 
-\date{December 2025}
+\date{May 2026}
 
 %=============================================================================
 \begin{document}
@@ -128,23 +128,21 @@ Philipp Rietz\\
 \thispagestyle{empty}
 
 \begin{abstract}
-We present a constructive proof of the existence and uniqueness of a 
-positive mass gap in quantum Yang-Mills theory for the gauge group 
-$\mathrm{SU}(3)$ on four-dimensional Euclidean space $\R^4$. The proof 
-extends pure Yang-Mills theory by coupling to a fundamental 
-information-density scalar field $S(x)$, which transforms as a gauge 
-singlet. Using the Extended Functional Renormalization Group (FRG) and 
-the Banach Fixed-Point Theorem, we establish the existence of a unique 
-mass gap $\Delta^* = 1.710 \pm 0.015\,\mathrm{GeV}$ with Lipschitz 
-constant $L = 3.749 \times 10^{-5} \ll 1$. The theory satisfies all 
-Osterwalder-Schrader axioms, enabling Wightman reconstruction. BRST 
-cohomology defines the physical Hilbert space $\Hilbert_{\mathrm{phys}} 
-= \ke Q / \im Q$ with positive-definite inner product. Gauge independence 
-follows from Nielsen identities, and RG invariance from the Callan-Symanzik 
-equation at the UV fixed point $5\kappa^2 = 3\lambda_S$. The scalar field 
-is auxiliary and can be integrated out, yielding pure Yang-Mills with 
-preserved mass gap via continuous deformation. The predicted mass gap 
-agrees with lattice QCD determinations (combined $z$-score $= 0.37$).
+We present an effective phenomenological derivation of a Yang-Mills spectral
+scale in the UIDT v3.9 framework. The construction introduces an effective
+information-density scalar field $S(x)$ and treats the infrared sector through
+a mean-field projection. Within this reduced algebraic model, the gap equation
+defines a local contraction with Lipschitz constant
+$L=3.749\times10^{-5}\ll1$ and a unique fixed point
+$\Delta^*=1.710\pm0.015\,\mathrm{GeV}$ [A, internal reduced-model closure].
+The mapping from this one-dimensional contraction to the full
+infinite-dimensional pure Yang-Mills path integral is not proven and remains
+an explicit Stratum III assumption [E]. The calibrated kinetic parameter
+$\gamma=16.339$ remains [A-], not RG-derived. Accordingly, this dossier does
+not claim a Clay Mathematics Institute proof of the Yang-Mills existence and
+mass gap problem. Its purpose is to document the hybrid method, numerical
+closure, lattice-compatible scale comparison, and falsifiable follow-up
+predictions without evidence inflation.
 \end{abstract}
 
 \tableofcontents
@@ -154,10 +152,10 @@ agrees with lattice QCD determinations (combined $z$-score $= 0.37$).
 % PART I: MAIN TEXT
 %=============================================================================
 
-\part{The Proof}
+\part{Effective Gap Derivation}
 
 %-----------------------------------------------------------------------------
-\section{Introduction: The Yang-Mills Mass Gap Problem}
+\section{Introduction: Yang-Mills Scale and Epistemic Boundary}
 \label{sec:introduction}
 %-----------------------------------------------------------------------------
 
@@ -170,22 +168,21 @@ Yang-Mills theory requires:
 quantum Yang-Mills theory exists on $\R^4$ and has a mass gap $\Delta > 0$.}
 \end{quote}
 
-This paper addresses the case $G = \mathrm{SU}(3)$, providing a constructive 
-proof that satisfies all requirements.
+This dossier does not claim to satisfy that standard. It documents an
+effective UIDT construction whose reduced algebraic sector is internally
+closed, while the pure-theory equivalence remains open.
 
-\subsection{Structure of the Proof}
+\subsection{Structure of the Hybrid Derivation}
 
-The proof proceeds through the following steps:
+The hybrid derivation proceeds through the following steps:
 \begin{enumerate}
 \item Definition of the augmented Lagrangian with scalar field $S(x)$
-\item Verification of Osterwalder-Schrader axioms (OS0--OS4)
-\item Wightman reconstruction to Minkowski signature
-\item BRST cohomology and physical Hilbert space
-\item Gauge independence via Nielsen identities
-\item RG invariance at UV fixed point
-\item Mass gap existence via Banach Fixed-Point Theorem
-\item Auxiliary field elimination and pure Yang-Mills limit
-\item Lattice QCD comparison
+\item Effective infrared mean-field projection [E]
+\item Reduced algebraic gap equation [A within the model]
+\item Local Banach fixed-point closure [A within the model]
+\item Calibration and lattice-compatible scale comparison [A-]/[B]
+\item Explicit documentation of the pure Yang-Mills boundary [E]
+\item Falsifiable tensor-glueball and finite-temperature predictions [D]
 \end{enumerate}
 
 %-----------------------------------------------------------------------------
@@ -195,19 +192,19 @@ The proof proceeds through the following steps:
 
 \subsection{Field Content}
 
-The theory contains:
+The effective theory contains:
 \begin{itemize}
 \item $A^a_\mu(x)$: $\mathrm{SU}(3)$ gauge field ($a = 1,\ldots,8$)
-\item $S(x)$: Real scalar field (gauge singlet, information-density field)
+\item $S(x)$: Real scalar field, treated here as an effective information-density field
 \item $c^a(x), \bar{c}^a(x)$: Faddeev-Popov ghosts
 \item $B^a(x)$: Nakanishi-Lautrup auxiliary field
 \end{itemize}
 
 \subsection{The Lagrangian Density}
 
-\begin{definition}[UIDT Lagrangian]
+\begin{definition}[UIDT Effective Lagrangian]
 \label{def:lagrangian}
-The complete gauge-fixed Lagrangian is:
+The complete gauge-fixed effective Lagrangian is:
 \begin{equation}
 \Lagr = \Lagr_{\mathrm{YM}} + \Lagr_S + \Lagr_{\mathrm{coupling}} 
 + \Lagr_{\mathrm{gf}} + \Lagr_{\mathrm{ghost}}
@@ -234,22 +231,26 @@ V(S) = \frac{1}{2}m_S^2 S^2 + \frac{\lambda_S}{4!}S^4
 \label{sec:os}
 %-----------------------------------------------------------------------------
 
-\begin{theorem}[OS Axioms Verification]
-The Schwinger functions of the UIDT satisfy all five Osterwalder-Schrader 
-axioms: Temperedness (OS0), Euclidean Covariance (OS1), Symmetry (OS2), 
-Cluster Property (OS3), and Reflection Positivity (OS4).
+\begin{theorem}[Reduced-Model OS Consistency Check]
+The Schwinger functions of the UIDT effective model are required to satisfy the
+Osterwalder-Schrader consistency conditions: Temperedness (OS0), Euclidean
+Covariance (OS1), Symmetry (OS2), Cluster Property (OS3), and Reflection
+Positivity (OS4). This statement is part of the reduced-model consistency
+program and is not a substitute for a completed construction of the pure
+Yang-Mills measure.
 \end{theorem}
 
-[Detailed proofs in Appendix A]
+[Detailed checks in Appendix A]
 
 %-----------------------------------------------------------------------------
 \section{Wightman Reconstruction}
 \label{sec:wightman}
 %-----------------------------------------------------------------------------
 
-\begin{theorem}[OS-Wightman Reconstruction]
-The OS axioms imply the existence of a Wightman QFT in Minkowski signature 
-with spectral gap $\Delta$.
+\begin{theorem}[Reduced-Model OS-Wightman Reconstruction]
+If the reduced effective model satisfies the OS axioms, Wightman reconstruction
+applies to that effective model. This does not by itself establish the same
+result for pure Yang-Mills theory.
 \end{theorem}
 
 %-----------------------------------------------------------------------------
@@ -259,7 +260,8 @@ with spectral gap $\Delta$.
 
 \begin{theorem}[BRST Nilpotency]
 \label{thm:nilpotency}
-The BRST operator $s$ satisfies $s^2 = 0$.
+The BRST operator $s$ satisfies $s^2 = 0$ within the effective gauge-fixed
+model.
 \end{theorem}
 
 \begin{definition}[Physical Hilbert Space]
@@ -278,7 +280,7 @@ The BRST operator $s$ satisfies $s^2 = 0$.
 
 \begin{theorem}[Nielsen Identity]
 \label{thm:nielsen}
-Physical observables are independent of the gauge parameter $\xi$:
+Physical observables of the effective model must be independent of the gauge parameter $\xi$:
 \begin{equation}
 \frac{\partial\Delta^*}{\partial\xi} = 0
 \end{equation}
@@ -289,9 +291,9 @@ Physical observables are independent of the gauge parameter $\xi$:
 \label{sec:rg}
 %-----------------------------------------------------------------------------
 
-\begin{theorem}[UV Fixed Point]
+\begin{theorem}[UV Fixed Point Constraint]
 \label{thm:fixed_point}
-The theory possesses a non-trivial UV fixed point satisfying:
+The reduced UIDT closure uses a fixed-point constraint satisfying:
 \begin{equation}
 5\kappa^{*2} = 3\lambda_S^*
 \end{equation}
@@ -299,32 +301,101 @@ with $\kappa^* = 0.500 \pm 0.008$.
 \end{theorem}
 
 %-----------------------------------------------------------------------------
-\section{The Mass Gap Theorem}
+\section{Effective Phenomenological Derivation of the Yang-Mills Scale}
 \label{sec:massgap}
 %-----------------------------------------------------------------------------
 
-\begin{theorem}[Main Result: Mass Gap Existence]
-\label{thm:main}
-In the UIDT extension of $\mathrm{SU}(3)$ Yang-Mills theory on $\R^4$:
-\begin{enumerate}[label=(\roman*)]
-\item There exists a unique mass gap $\Delta^* = 1.710 \pm 0.015\,\mathrm{GeV}$
-\item The gap equation defines a contraction mapping with $L = 3.749 \times 10^{-5}$
-\item Convergence is established via the Banach Fixed-Point Theorem
-\end{enumerate}
-\end{theorem}
+\subsection{The Effective Mean-Field Projection}
 
-[Detailed numerical verification in Appendix C]
+Instead of claiming a global proof over the full infinite-dimensional
+functional space of pure Yang-Mills theory, we formulate an effective infrared
+projection. We assume that the non-perturbative vacuum dynamics can be
+parameterized by coupling to an effective scalar information-density field
+$S(x)$.
+
+Under the additional assumption that the infrared system is dominated by the
+model condensate input $\mathcal C$, the path integral is reduced to an
+algebraic gap equation. The exact topological equivalence between this
+reduction and pure Yang-Mills theory remains an open conjectural step [E].
+
+\subsection{The Algebraic Gap Equation and Local Banach Iteration}
+
+Within the reduced effective model, define
+\[
+T(\Delta)=
+\sqrt{
+m_S^2+
+\frac{\kappa^2\mathcal C}{4\Lambda^2}
+\left[
+1+\frac{\ln(\Lambda^2/\Delta^2)}{16\pi^2}
+\right]
+}.
+\]
+
+The deterministic fixed-point constraint is
+\[
+5\kappa^2=3\lambda_S,
+\qquad
+\lambda_S=\frac{5}{12}
+\quad\text{for}\quad
+\kappa=\frac12.
+\]
+The residual is therefore exactly zero in rational arithmetic and must remain
+below $10^{-14}$ in numerical verification.
+
+The local derivative of the reduced operator is
+\[
+T'(\Delta)
+=-\frac{\alpha\beta}{\Delta T(\Delta)},
+\qquad
+\alpha=\frac{\kappa^2\mathcal C}{4\Lambda^2},
+\quad
+\beta=\frac{1}{16\pi^2}.
+\]
+Near the fixed point,
+\[
+L\simeq 3.749\times10^{-5}\ll1.
+\]
+
+Consequently, $T$ is a strong local contraction for the reduced one-dimensional
+model interval. Banach iteration gives
+\[
+\Delta^*
+=1.710035046742213182020771096614\ldots\,\mathrm{GeV}.
+\]
+This is an [A] statement about the reduced model only.
+
+\subsection{Phenomenological Calibration}
+
+The numerical scale is not a purely ab-initio prediction from the
+dimensionless Yang-Mills coupling $g$. It depends on the external/model
+condensate input $\mathcal C$ and on the calibrated kinetic parameter
+$\gamma=16.339$ [A-]. The closure demonstrates internal consistency of the
+hybrid parameter system, not a complete proof of the Clay problem.
+
+\subsection{Acknowledged Limitations}
+
+\begin{enumerate}
+\item The contraction proof is local and one-dimensional; it is not a proof on
+      the full measure of the infinite-dimensional QFT path integral.
+\item Removing the auxiliary/effective field $S(x)$ by a smooth deformation is
+      not trivial in QFT. Haag-type obstructions and phase transitions cannot
+      be excluded by the current argument.
+\item The use of condensate inputs classifies the construction as an effective
+      phenomenological model, not as a pure axiomatic derivation from $g$ alone.
+\end{enumerate}
 
 %-----------------------------------------------------------------------------
-\section{Auxiliary Field Elimination}
+\section{Auxiliary Field Boundary}
 \label{sec:auxiliary}
 %-----------------------------------------------------------------------------
 
-\begin{theorem}[Auxiliary Field]
-\label{thm:auxiliary}
-The scalar field $S(x)$ can be integrated out via Gaussian path integral, 
-yielding an effective pure Yang-Mills action with induced mass gap.
-\end{theorem}
+\begin{remark}[Auxiliary Field Boundary]
+The scalar field $S(x)$ may be integrated out in the reduced effective model to
+generate induced Yang-Mills-sector operators. This does not prove that the
+resulting effective action is continuously equivalent to pure Yang-Mills theory
+without phase transition or spectral discontinuity.
+\end{remark}
 
 [Details in Appendix D]
 
@@ -335,9 +406,10 @@ yielding an effective pure Yang-Mills action with induced mass gap.
 
 \begin{theorem}[Lattice Compatibility]
 \label{thm:compatibility}
-The UIDT mass gap $\Delta^* = 1.710 \pm 0.015\,\mathrm{GeV}$ agrees with 
-lattice QCD determinations with combined $z$-score $= 0.37$, 
-corresponding to $p$-value $> 0.75$.
+The UIDT reduced-model scale $\Delta^* = 1.710 \pm 0.015\,\mathrm{GeV}$ is
+compatible with selected lattice QCD determinations under the stated
+normalization and uncertainty conventions. This is a [B] comparison statement,
+not a proof of the pure Yang-Mills spectrum.
 \end{theorem}
 
 %-----------------------------------------------------------------------------
@@ -345,20 +417,22 @@ corresponding to $p$-value $> 0.75$.
 \label{sec:conclusion}
 %-----------------------------------------------------------------------------
 
-We have established a constructive proof of the Yang-Mills mass gap for 
-$\mathrm{SU}(3)$ gauge theory on $\R^4$. The proof satisfies all 21 Clay 
-Institute requirements, including OS axioms, Wightman reconstruction, 
-BRST cohomology, gauge independence, and RG invariance.
+We have documented an effective phenomenological derivation of a Yang-Mills
+spectral scale within UIDT v3.9. The reduced gap equation is internally closed
+and numerically stable, but this does not constitute a Clay-level proof of pure
+Yang-Mills existence and mass gap.
 
 \subsection{Methodological Limitations}
 
 \begin{enumerate}
-\item \textbf{Scalar Field Extension:} The proof employs a scalar field 
-      $S(x)$ not present in pure Yang-Mills. The auxiliary field elimination 
-      establishes the connection to pure Yang-Mills.
-\item \textbf{Gauge Group:} The proof is given for $\mathrm{SU}(3)$ only.
-\item \textbf{Deformation Limit:} The continuous deformation to pure 
-      Yang-Mills is conceptually clear but not formalized as rigorous homotopy.
+\item \textbf{Scalar Field Extension:} The construction employs an effective
+      scalar field $S(x)$ not present in pure Yang-Mills. The connection to pure
+      Yang-Mills remains an open projection-equivalence problem [E].
+\item \textbf{Gauge Group:} The current numerical scale is stated for the
+      $\mathrm{SU}(3)$ sector.
+\item \textbf{Deformation Limit:} The continuous deformation to pure Yang-Mills
+      is not formalized as rigorous homotopy and cannot be used as a Clay-level
+      conclusion.
 \end{enumerate}
 
 \input{UIDT_Chapter_7_QuarkMassHierarchy}

--- a/manuscript/UIDT_v3.9-Complete-Framework.tex
+++ b/manuscript/UIDT_v3.9-Complete-Framework.tex
@@ -206,8 +206,8 @@
 {\large Version 3.9 -- The Geometric Operator}\\[1cm]
 {\Huge\bfseries Vacuum Information Density\\[0.3cm] 
 as the Fundamental Geometric Scalar}\\[0.5cm]
-{\Large\itshape A Proposed Theoretical Framework for the\\[0.2cm]
-Yang--Mills Mass Gap and Gamma-Scaling Unification}\\[3cm]
+{\Large\itshape An Effective Phenomenological Derivation of the\\[0.2cm]
+Yang--Mills Scale and Gamma-Scaling Unification}\\[3cm]
 {\large Philipp Rietz}\\[0.3cm]
 {\normalsize Independent Researcher}\\
 {\small ORCID: 0009-0007-4307-1609}\\
@@ -238,8 +238,8 @@ gap via vacuum condensate mechanisms.
 \textbf{Mathematical Core (The Upgrade):}
 Canonical parameters are now rigorously derived from a self-consistent system
 of three coupled equations. Utilizing the Extended Functional Renormalization
-Group (FRG) and the \textbf{Banach Fixed-Point Theorem}, we provide a
-constructive derivation of the existence of a unique stable solution. This yields
+Group (FRG) and the \textbf{Banach Fixed-Point Theorem}, we provide an
+effective phenomenological derivation of a unique stable vacuum scale. This yields
 the Yang-Mills spectral gap $\Delta = 1.710035\dots\,\GeV$, coupling
 $\kappa = 0.500 \pm 0.008$, and the universal invariant
 $\gamma \approx 16.339$. The derivation is verified by a 60-digit numerical
@@ -450,10 +450,10 @@ CSF-UIDT Synthesis; Falsification Matrix; Osterwalder--Schrader axioms; UIDT
 \section{Introduction}
 \label{sec:introduction}
 
-The Yang--Mills Existence and Mass Gap problem, one of the Clay Mathematics 
-Institute's Millennium Prize Problems, requires rigorous demonstration that 
-quantum Yang--Mills theory possesses a strictly positive mass gap $\Delta > 0$ 
-with mathematical proof. Simultaneously, precision cosmology faces significant 
+The fundamental understanding of the Yang-Mills sector requires describing how 
+a strictly positive mass scale $\Delta > 0$ dynamically emerges. Rather than 
+claiming a global axiomatic proof for the Clay Millennium Prize, this framework 
+establishes a constructive, effective model to derive this scale. Simultaneously, precision cosmology faces significant 
 tensions between early- and late-universe measurements, including the Hubble 
 constant discrepancy ($5\sigma$ between Planck and SH0ES) and structure 
 formation tension ($S_8$ disagreement between CMB lensing and weak gravitational lensing).

--- a/manuscript/patches/UIDT_v3.9_Complete_Framework_epistemic_reframe.patch.md
+++ b/manuscript/patches/UIDT_v3.9_Complete_Framework_epistemic_reframe.patch.md
@@ -1,0 +1,152 @@
+# UIDT v3.9 Complete Framework — Line-Aware Epistemic Reframe Patch
+
+**Target file:** `manuscript/UIDT_v3.9-Complete-Framework.tex`  
+**PR context:** `fix/line-aware-proof-language-cleanup-2026-05-25` / PR #512  
+**Reason:** The GitHub connector truncates the full manuscript payload on read, while `update_file` requires complete-file replacement. Direct automated replacement is therefore intentionally avoided to prevent file truncation.  
+**Status:** Apply locally or with a line-aware patch tool.
+
+---
+
+## Scope
+
+This patch changes only framing language. It does not alter equations, constants, derivations, numerical values, bibliography, author identity, ORCID, DOI, or license information.
+
+Evidence consequence:
+
+| Claim | Status after patch |
+|---|---|
+| Reduced algebraic closure | [A], internal reduced-model statement |
+| `gamma = 16.339` | [A-], calibrated |
+| Yang--Mills pure-theory equivalence | [E], open |
+| Hybrid predictions | [D], falsifiable |
+
+---
+
+## Replacement 1 — Document Header
+
+### Find
+
+```latex
+{\Large\scshape Unified Information-Density Theory}\\[0.5cm]
+{\large Version 3.9 -- The Geometric Operator}\\[1cm]
+{\Huge\bfseries Vacuum Information Density\\[0.3cm] 
+as the Fundamental Geometric Scalar}\\[0.5cm]
+{\Large\itshape A Proposed Theoretical Framework for the\\[0.2cm]
+Yang--Mills Mass Gap and Gamma-Scaling Unification}\\[3cm]
+```
+
+### Replace with
+
+```latex
+{\Large\scshape Unified Information-Density Theory}\\[0.5cm]
+{\large Version 3.9 -- The Geometric Operator}\\[1cm]
+{\Huge\bfseries Vacuum Information Density\\[0.3cm] 
+as the Fundamental Geometric Scalar}\\[0.5cm]
+{\Large\itshape An Effective Phenomenological Derivation of the\\[0.2cm]
+Yang--Mills Scale and Gamma-Scaling Unification}\\[3cm]
+```
+
+---
+
+## Replacement 2 — Abstract Claim
+
+### Find
+
+```latex
+Utilizing the Extended Functional Renormalization
+Group (FRG) and the \textbf{Banach Fixed-Point Theorem}, we provide a
+constructive derivation of the existence of a unique stable solution.
+```
+
+### Replace with
+
+```latex
+Utilizing the Extended Functional Renormalization
+Group (FRG) and the \textbf{Banach Fixed-Point Theorem}, we provide an
+effective phenomenological derivation of a unique stable vacuum scale.
+```
+
+---
+
+## Replacement 3 — Section 1 Introduction
+
+### Find
+
+```latex
+The Yang--Mills Existence and Mass Gap problem, one of the Clay Mathematics 
+Institute's Millennium Prize Problems, requires rigorous demonstration that 
+quantum Yang--Mills theory possesses a strictly positive mass gap $\Delta > 0$ 
+with mathematical proof.
+```
+
+### Replace with
+
+```latex
+The fundamental understanding of the Yang-Mills sector requires describing how 
+a strictly positive mass scale $\Delta > 0$ dynamically emerges. Rather than 
+claiming a global axiomatic proof for the Clay Millennium Prize, this framework 
+establishes a constructive, effective model to derive this scale.
+```
+
+---
+
+## Local Verification Command
+
+From the repository root:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+
+path = Path('manuscript/UIDT_v3.9-Complete-Framework.tex')
+text = path.read_text(encoding='utf-8')
+
+replacements = [
+    (
+        """{\\Large\\scshape Unified Information-Density Theory}\\\\[0.5cm]\n{\\large Version 3.9 -- The Geometric Operator}\\\\[1cm]\n{\\Huge\\bfseries Vacuum Information Density\\\\[0.3cm] \nas the Fundamental Geometric Scalar}\\\\[0.5cm]\n{\\Large\\itshape A Proposed Theoretical Framework for the\\\\[0.2cm]\nYang--Mills Mass Gap and Gamma-Scaling Unification}\\\\[3cm]""",
+        """{\\Large\\scshape Unified Information-Density Theory}\\\\[0.5cm]\n{\\large Version 3.9 -- The Geometric Operator}\\\\[1cm]\n{\\Huge\\bfseries Vacuum Information Density\\\\[0.3cm] \nas the Fundamental Geometric Scalar}\\\\[0.5cm]\n{\\Large\\itshape An Effective Phenomenological Derivation of the\\\\[0.2cm]\nYang--Mills Scale and Gamma-Scaling Unification}\\\\[3cm]""",
+    ),
+    (
+        """Utilizing the Extended Functional Renormalization\nGroup (FRG) and the \\textbf{Banach Fixed-Point Theorem}, we provide a\nconstructive derivation of the existence of a unique stable solution.""",
+        """Utilizing the Extended Functional Renormalization\nGroup (FRG) and the \\textbf{Banach Fixed-Point Theorem}, we provide an\neffective phenomenological derivation of a unique stable vacuum scale.""",
+    ),
+    (
+        """The Yang--Mills Existence and Mass Gap problem, one of the Clay Mathematics \nInstitute's Millennium Prize Problems, requires rigorous demonstration that \nquantum Yang--Mills theory possesses a strictly positive mass gap $\\Delta > 0$ \nwith mathematical proof.""",
+        """The fundamental understanding of the Yang-Mills sector requires describing how \na strictly positive mass scale $\\Delta > 0$ dynamically emerges. Rather than \nclaiming a global axiomatic proof for the Clay Millennium Prize, this framework \nestablishes a constructive, effective model to derive this scale.""",
+    ),
+]
+
+for old, new in replacements:
+    if old not in text:
+        raise SystemExit(f'[PATCH_FAIL] target block not found:\n{old}')
+    text = text.replace(old, new, 1)
+
+path.write_text(text, encoding='utf-8')
+print('[PASS] Applied 3 line-aware epistemic reframe replacements.')
+PY
+```
+
+Then inspect:
+
+```bash
+git diff -- manuscript/UIDT_v3.9-Complete-Framework.tex
+```
+
+Expected changed blocks only:
+
+1. title page subtitle;
+2. abstract derivation sentence;
+3. first paragraph of Section 1.
+
+---
+
+## Non-Inflation Statement
+
+This patch does not demote internal mathematical closure. It restricts the public claim to what is actually established:
+
+- reduced-model Banach fixed-point closure [A];
+- calibrated gamma sector [A-];
+- lattice compatibility and comparison [B];
+- cosmological calibration [C];
+- phenomenological predictions [D];
+- full pure Yang--Mills equivalence [E/open].


### PR DESCRIPTION
## Summary

This draft PR performs a focused, line-aware cleanup of residual proof-language in the root `README.md`, the modular Clay manuscript entry point `clay-submission/01_Manuscript/main.tex`, and the integrated manuscript `manuscript/UIDT_v3.9-Complete-Framework.tex`.

The integrated manuscript was patched locally with the exact line-aware replacement script documented in `manuscript/patches/UIDT_v3.9_Complete_Framework_epistemic_reframe.patch.md`. The resulting commit modifies only the expected three text blocks: title subtitle, abstract derivation sentence, and first paragraph of Section 1.

This PR also adds a root-level **Numerical Transparency Statement** to make explicit that 80-digit arithmetic is a reproducibility and integrity control, not a claim of 80-digit physical measurement precision.

This PR does not merge PR #511 and does not change canonical constants, numerical kernels, `core/`, `modules/`, `CANONICAL/`, `LEDGER/`, `UIDT-OS/`, or release files.

## Branch

`fix/line-aware-proof-language-cleanup-2026-05-25`

## Scope

Changed files: 4

| File | Purpose |
|---|---|
| `README.md` | Replace overclaiming around Yang-Mills proof, cosmological closure, and direct glueball claims with evidence-tagged reduced-model language; add Numerical Transparency Statement. |
| `clay-submission/01_Manuscript/main.tex` | Reframe the modular Clay-facing manuscript from proof/submission wording to effective phenomenological derivation dossier. |
| `manuscript/UIDT_v3.9-Complete-Framework.tex` | Apply the three line-aware epistemic reframing replacements to the integrated manuscript. |
| `manuscript/patches/UIDT_v3.9_Complete_Framework_epistemic_reframe.patch.md` | Preserves the exact local patch procedure and verification instructions used for the integrated manuscript. |

## Wording Changes

### Removed or downgraded

- `Analytical derivation of Yang-Mills mass gap`
- `derives the Yang-Mills Mass Gap`
- `Constructive proof of the Yang-Mills Mass Gap`
- `The Proof`
- `proof that satisfies all requirements`
- `Internal proof complete`
- direct glueball resonance framing as established observation
- cosmological-constant closure wording

### Authorized replacements

- `effective phenomenological derivation`
- `reduced-model closure`
- `effective Yang-Mills spectral scale`
- `lattice-compatible scale`
- `open Stratum III assumption [E]`
- `constructive framework`
- `suggests` / `compatible with` where appropriate

## Numerical Transparency Statement

The new root-level transparency note states:

- 80-digit arithmetic is a reproducibility and integrity control.
- 80-digit numerical output is not a claim of 80-digit experimental accuracy.
- [A] claims remain restricted to internally specified mathematical subsystems.
- [D] predictions remain unverified until independent measurement.
- [E] interpretive mappings remain model hypotheses, especially when fitted parameters are required.
- Deviations between reduced-model output and empirical systems must be reported rather than absorbed by undocumented tuning.

## Claims Table

| Claim ID | Claim | Value | Evidence Tag | Stratum | Source | Status | Falsification Exposure |
|---|---|---:|---:|---:|---|---|---|
| CLEAN-README-001 | Root overview no longer states a Clay-level Yang-Mills proof. | wording correction | [E]/[A] boundary | III | `README.md` | corrected | repository-level overclaiming |
| CLEAN-README-002 | Root overview states `Delta*` as reduced-model spectral scale. | `1.710 +/- 0.015 GeV` | [A] internal | III | `README.md` | corrected | lattice exclusion >3 sigma |
| CLEAN-README-003 | Root overview now separates 80-dps reproducibility from physical precision. | transparency statement | [E]/[A] boundary | III | `README.md` | corrected | numerical overinterpretation |
| CLEAN-CLAY-001 | Modular Clay entry point no longer claims to satisfy Clay requirements. | wording correction | [E] boundary | III | `clay-submission/01_Manuscript/main.tex` | corrected | pure-theory projection gap |
| CLEAN-CLAY-002 | Clay manuscript now states the effective projection boundary explicitly. | projection open | [E] | III | `clay-submission/01_Manuscript/main.tex` | corrected | measure/path-integral construction |
| CLEAN-MSCRIPT-001 | Integrated manuscript title subtitle reframed. | title wording correction | [E]/[A] boundary | III | `manuscript/UIDT_v3.9-Complete-Framework.tex` | applied | overclaiming in master manuscript |
| CLEAN-MSCRIPT-002 | Integrated manuscript abstract reframed. | abstract wording correction | [E]/[A] boundary | III | `manuscript/UIDT_v3.9-Complete-Framework.tex` | applied | overclaiming in master manuscript |
| CLEAN-MSCRIPT-003 | Integrated manuscript Section 1 Clay claim reframed. | introduction wording correction | [E]/[A] boundary | III | `manuscript/UIDT_v3.9-Complete-Framework.tex` | applied | pure-theory projection gap |

## Stratum Declaration

| Stratum | Treatment in this PR |
|---|---|
| Stratum I | No new empirical or lattice values are introduced. Existing lattice compatibility language is retained only as comparison. |
| Stratum II | No consensus claim is promoted. |
| Stratum III | UIDT interpretation is explicitly restricted to reduced-model closure and effective phenomenological derivation. |

## Reproduction Note

No numerical behavior is changed in this PR. For the linked effective-gap prediction verification introduced in PR #511, use:

```bash
python verification/scripts/verify_effective_gap_predictions.py
```

For the full legacy verification suite, use the repository-standard command:

```bash
python verification/scripts/UIDT_Master_Verification.py
```

The integrated manuscript patch was applied locally from the exact Python block documented in:

```text
manuscript/patches/UIDT_v3.9_Complete_Framework_epistemic_reframe.patch.md
```

The local verification confirmed that only the expected three integrated-manuscript blocks changed:

1. title page subtitle;
2. abstract derivation sentence;
3. first paragraph of Section 1.

## DOI/arXiv Resolvability

No new external DOI/arXiv source is introduced in this cleanup PR. Existing source references in the modified files are preserved. Claim cannot be promoted on the basis of this cleanup alone.

## Review Gates

- [x] No merge into `main`.
- [x] Branch: `fix/line-aware-proof-language-cleanup-2026-05-25`.
- [x] Changed files verified: 4.
- [x] Integrated manuscript patch applied locally and pushed as commit `122fc9f`.
- [x] Numerical Transparency Statement added to root `README.md` as commit `1eda58f`.
- [x] No changes to protected numerical/code folders.
- [x] Maintained author/signature information: `Philipp Rietz` remains in edited files where applicable.
- [x] No canonical constants changed.
- [x] No full-file connector rewrite of the integrated manuscript was used.

## Release Naming Note

If this cleanup is later packaged as a release artifact, use the required pattern:

`update_2026-05-25_line-aware-proof-language-cleanup_TKT-2026-05-25`