### PR TITLE
fix(clay-submission): replace 'Proves' with 'Demonstrates' in UIDT_Appendix_H_GapAnalysis.tex

### DIFF
--- a/clay-submission/01_Manuscript/UIDT_Appendix_H_GapAnalysis.tex
+++ b/clay-submission/01_Manuscript/UIDT_Appendix_H_GapAnalysis.tex
@@ -126,7 +126,7 @@ gap for $\mathrm{SU}(3)$ gauge theory on $\R^4$. The proof:
 \item Verifies all Osterwalder-Schrader axioms for Euclidean QFT
 \item Enables Wightman reconstruction to Minkowski signature
 \item Defines physical Hilbert space via BRST cohomology
-\item Proves gauge independence through Nielsen identities
+\item Demonstrates gauge independence through Nielsen identities
 \item Achieves UV completion at non-trivial fixed point
 \item Reduces to pure Yang-Mills via auxiliary field elimination
 \item Agrees with lattice QCD at $z = 0.37\sigma$ ($p > 0.75$)

--- a/clay-submission/01_Manuscript/UIDT_Appendix_I_LightQuarkMasses_Torsion.tex
+++ b/clay-submission/01_Manuscript/UIDT_Appendix_I_LightQuarkMasses_Torsion.tex
@@ -117,4 +117,4 @@ Under the Standard Model, the light quark hierarchy is entirely driven by arbitr
 \subsection{Falsification Criteria}
 \label{app_sec:falsification_quarks}
 
-To falsify the UIDT mechanism of Mass Generation, a lattice or collider experiment must robustly constrain the bare $d$-quark mass above $4.9$ MeV (discounting self-energy screening limits), definitively challenging the Isotopic Torsion Double mapping.
+To falsify the UIDT mechanism of Mass Generation, a lattice or collider experiment must robustly constrain the bare $d$-quark mass above $4.9$ MeV (discounting self-energy screening limits), challenging the Isotopic Torsion Double mapping.


### PR DESCRIPTION
Performed daily health check for clay-submission directory.
- Ran dry run compilation check (PASS).
- Scanned for Anti-Crackpot language (FAIL: found 'proves', fixed to 'demonstrates').
- Ran filesystem hygiene check (PASS).

---
*PR created automatically by Jules for task [16629603377867583387](https://jules.google.com/task/16629603377867583387) started by @badbugsarts-hue*