### PR TITLE
Fix bibliography links and apply language policy in clay-submission

### DIFF
--- a/clay-submission/01_Manuscript/UIDT_Appendix_C_Numerical.tex
+++ b/clay-submission/01_Manuscript/UIDT_Appendix_C_Numerical.tex
@@ -78,7 +78,7 @@ Identifying $\Delta^2 = m_{\mathrm{pole}}^2$ yields the gap equation.
 $m_S$ & 1.705 GeV & $\pm 0.015$ GeV & Gap equation solution \\
 $\kappa$ & 0.500 & $\pm 0.008$ & RG fixed point \\
 $\lambda_S$ & 0.417 & $\pm 0.007$ & $5\kappa^2 = 3\lambda_S$ \\
-$\mathcal{C}$ & 0.277 GeV$^4$ & $\pm 0.014$ GeV$^4$ & SVZ sum rules~\cite{SVZ1979} \\
+$\mathcal{C}$ & 0.277 GeV$^4$ & $\pm 0.014$ GeV$^4$ & SVZ sum rules~\cite{ShifmanVainshteinZakharov1979} \\
 $\Lambda$ & 1.0 GeV & --- & Renormalization scale \\
 $\alpha_s(1\,\mathrm{GeV})$ & 0.50 & $\pm 0.05$ & Non-perturbative regime \\
 \bottomrule
@@ -358,7 +358,7 @@ Check: dimensionless \checkmark
 \textbf{Study} & \textbf{$m_{0^{++}}$ (GeV)} & \textbf{$\sigma$ (GeV)} & 
 \textbf{$z$-score} & \textbf{Method} \\
 \midrule
-Morningstar \& Peardon~\cite{Morningstar1999} & 1.730 & 0.050 & 0.39 & Anisotropic \\
+Morningstar \& Peardon~\cite{MorningstarPeardon1999} & 1.730 & 0.050 & 0.39 & Anisotropic \\
 Chen et al.~\cite{Chen2006} & 1.710 & 0.050 & 0.00 & Improved \\
 Athenodorou et al.~\cite{Athenodorou2021} & 1.756 & 0.039 & 1.10 & Large volume \\
 Meyer~\cite{Meyer2005} & 1.710 & 0.040 & 0.00 & Wilson \\

--- a/clay-submission/01_Manuscript/UIDT_Appendix_H_GapAnalysis.tex
+++ b/clay-submission/01_Manuscript/UIDT_Appendix_H_GapAnalysis.tex
@@ -126,7 +126,7 @@ gap for $\mathrm{SU}(3)$ gauge theory on $\R^4$. The proof:
 \item Verifies all Osterwalder-Schrader axioms for Euclidean QFT
 \item Enables Wightman reconstruction to Minkowski signature
 \item Defines physical Hilbert space via BRST cohomology
-\item Proves gauge independence through Nielsen identities
+\item Demonstrates gauge independence through Nielsen identities
 \item Achieves UV completion at non-trivial fixed point
 \item Reduces to pure Yang-Mills via auxiliary field elimination
 \item Agrees with lattice QCD at $z = 0.37\sigma$ ($p > 0.75$)

--- a/clay-submission/REFERENCES.bib
+++ b/clay-submission/REFERENCES.bib
@@ -272,3 +272,13 @@
   pages        = {015001},
   year         = {2016}
 }
+
+@article{Nielsen1975,
+  author  = {Nielsen, N. K.},
+  title   = {On the Gauge Dependence of Spontaneous Symmetry Breaking in Gauge Theories},
+  journal = {Nucl. Phys. B},
+  volume  = {101},
+  pages   = {173--188},
+  year    = {1975},
+  doi     = {10.1016/0550-3213(75)90301-6}
+}

--- a/health_report.md
+++ b/health_report.md
@@ -1,0 +1,6 @@
+### UIDT Clay Submission Health Report (Daily)
+- **Compilation Status:** [PASS] Bibliography errors resolved.
+- **Language Policy Compliance:** [PASS] Replaced 'proves' with 'demonstrates' where applicable.
+- **Filesystem Integrity:** [PASS] No root violations found.
+
+**Action Taken:** PR für Syntax/Filesystem-Fix auf Feature-Branch TKT-2024-06-10-daily-health-check-001 erstellt


### PR DESCRIPTION
Performed the daily health check for the `clay-submission/` directory according to constraints:
- Compiled LaTeX (dry run) and fixed missing bibliography references
- Scanned for forbidden crackpot words and replaced "Proves" with "Demonstrates"
- Checked filesystem hygiene (no violations)
- Generated `health_report.md` with results

---
*PR created automatically by Jules for task [7887972222437279827](https://jules.google.com/task/7887972222437279827) started by @badbugsarts-hue*